### PR TITLE
[WIP] Encode WebAssembly specific locations in DBG_VALUEs and DW_AT_frame_base

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Dwarf.def
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.def
@@ -627,6 +627,8 @@ HANDLE_DW_OP(0xa9, reinterpret, 5, DWARF)
 // Vendor extensions:
 // Extensions for GNU-style thread-local storage.
 HANDLE_DW_OP(0xe0, GNU_push_tls_address, 0, GNU)
+// Extensions for WebAssembly.
+HANDLE_DW_OP(0xed, WASM_location, 0, WASM)
 // Extensions for Fission proposal.
 HANDLE_DW_OP(0xfb, GNU_addr_index, 0, GNU)
 HANDLE_DW_OP(0xfc, GNU_const_index, 0, GNU)

--- a/llvm/include/llvm/BinaryFormat/Dwarf.h
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.h
@@ -59,7 +59,8 @@ enum LLVMConstants : uint32_t {
   DWARF_VENDOR_GNU = 3,
   DWARF_VENDOR_GOOGLE = 4,
   DWARF_VENDOR_LLVM = 5,
-  DWARF_VENDOR_MIPS = 6
+  DWARF_VENDOR_MIPS = 6,
+  DWARF_VENDOR_WASM = 7
 };
 
 /// Constants that define the DWARF format as 32 or 64 bit.

--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -211,6 +211,22 @@ struct RegClassWeight {
   unsigned WeightLimit;
 };
 
+struct FrameBaseLocation {
+  enum LocationKind {
+    Register,
+    CFA,
+    TargetIndex
+  } Kind;
+  struct TargetIndexInfo {
+    unsigned Index;
+    signed Offset;
+  };
+  union {
+    unsigned Reg;
+    TargetIndexInfo TI;
+  };
+};
+
 /// TargetRegisterInfo base class - We assume that the target defines a static
 /// array of TargetRegisterDesc objects that represent all of the machine
 /// registers that the target has.  As such, we simply have to track a pointer
@@ -987,6 +1003,13 @@ public:
   /// getFrameRegister - This method should return the register used as a base
   /// for values allocated in the current stack frame.
   virtual unsigned getFrameRegister(const MachineFunction &MF) const = 0;
+
+  virtual FrameBaseLocation getFrameBaseLocation(const MachineFunction &MF) const {
+    FrameBaseLocation Loc;
+    Loc.Kind = FrameBaseLocation::Register;
+    Loc.Reg = getFrameRegister(MF);
+    return Loc;
+  }
 
   /// Mark a register and all its aliases as reserved in the given set.
   void markSuperRegs(BitVector &RegisterSet, unsigned Reg) const;

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -895,6 +895,10 @@ static bool emitDebugValueComment(const MachineInstr *MI, AsmPrinter &AP) {
     OS << MI->getOperand(0).getImm();
   } else if (MI->getOperand(0).isCImm()) {
     MI->getOperand(0).getCImm()->getValue().print(OS, false /*isSigned*/);
+  } else if (MI->getOperand(0).isTargetIndex()) {
+    auto Op = MI->getOperand(0);
+    OS << "!target-index(" << Op.getIndex() << "," << Op.getOffset() << ")";
+    return true;
   } else {
     unsigned Reg;
     if (MI->getOperand(0).isReg()) {

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
@@ -340,13 +340,24 @@ DIE &DwarfCompileUnit::updateSubprogramScopeDIE(const DISubprogram *SP) {
 
   // Only include DW_AT_frame_base in full debug info
   if (!includeMinimalInlineScopes()) {
-    if (Asm->MF->getTarget().getTargetTriple().isNVPTX()) {
+    const TargetRegisterInfo *RI = Asm->MF->getSubtarget().getRegisterInfo();
+    auto FBL = RI->getFrameBaseLocation(*Asm->MF);
+    if (FBL.Kind == FrameBaseLocation::CFA) {
       DIELoc *Loc = new (DIEValueAllocator) DIELoc;
       addUInt(*Loc, dwarf::DW_FORM_data1, dwarf::DW_OP_call_frame_cfa);
       addBlock(*SPDie, dwarf::DW_AT_frame_base, Loc);
+    } else if (FBL.Kind == FrameBaseLocation::TargetIndex) {
+      if (FBL.TI.Offset >= 0) {
+        DIELoc *Loc = new (DIEValueAllocator) DIELoc;
+        DIEDwarfExpression DwarfExpr(*Asm, *this, *Loc);
+        DIExpressionCursor Cursor({});
+        DwarfExpr.addTargetIndexLocation(FBL.TI.Index, FBL.TI.Offset);
+        DwarfExpr.addExpression(std::move(Cursor));
+        addBlock(*SPDie, dwarf::DW_AT_frame_base, DwarfExpr.finalize());
+      }
     } else {
-      const TargetRegisterInfo *RI = Asm->MF->getSubtarget().getRegisterInfo();
-      MachineLocation Location(RI->getFrameRegister(*Asm->MF));
+      assert(FBL.Kind == FrameBaseLocation::Register);
+      MachineLocation Location(FBL.Reg);
       if (RI->isPhysicalRegister(Location.getReg()))
         addAddress(*SPDie, dwarf::DW_AT_frame_base, Location);
     }

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -1072,6 +1072,11 @@ static DebugLocEntry::Value getDebugLocValue(const MachineInstr *MI) {
     MachineLocation MLoc(RegOp.getReg(), Op1.isImm());
     return DebugLocEntry::Value(Expr, MLoc);
   }
+  if (MI->getOperand(0).isTargetIndex()) {
+    auto Op = MI->getOperand(0);
+    return DebugLocEntry::Value(
+        Expr, TargetIndexLocation(Op.getIndex(), Op.getOffset()));
+  }
   if (MI->getOperand(0).isImm())
     return DebugLocEntry::Value(Expr, MI->getOperand(0).getImm());
   if (MI->getOperand(0).isFPImm())
@@ -1920,6 +1925,9 @@ static void emitDebugLocValue(const AsmPrinter &AP, const DIBasicType *BT,
     if (!DwarfExpr.addMachineRegExpression(TRI, Cursor, Location.getReg()))
       return;
     return DwarfExpr.addExpression(std::move(Cursor));
+  } else if (Value.isTargetIndexLocation()) {
+    TargetIndexLocation Loc = Value.getTargetIndexLocation();
+    DwarfExpr.addTargetIndexLocation(Loc.Index, Loc.Offset);
   } else if (Value.isConstantFP()) {
     APInt RawBytes = Value.getConstantFP()->getValueAPF().bitcastToAPInt();
     DwarfExpr.addUnsignedConstant(RawBytes);

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
@@ -437,3 +437,11 @@ void DwarfExpression::addFragmentOffset(const DIExpression *Expr) {
     addOpPiece(FragmentOffset - OffsetInBits);
   OffsetInBits = FragmentOffset;
 }
+
+void DwarfExpression::addTargetIndexLocation(unsigned Index, int64_t Offset) {
+  assert(LocationKind == Implicit || LocationKind == Unknown);
+  LocationKind = Implicit;
+  emitOp(dwarf::DW_OP_WASM_location);
+  emitUnsigned(Index);
+  emitSigned(Offset);
+}

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
@@ -248,6 +248,10 @@ public:
   /// If applicable, emit an empty DW_OP_piece / DW_OP_bit_piece to advance to
   /// the fragment described by \c Expr.
   void addFragmentOffset(const DIExpression *Expr);
+
+  /// Emit location information expressed via target's index + offset
+  /// It is an extension for WebAssembly locals, globals and operand stack.
+  void addTargetIndexLocation(unsigned Index, int64_t Offset);
 };
 
 /// DwarfExpression implementation for .debug_loc entries.

--- a/llvm/lib/DebugInfo/DWARF/DWARFExpression.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFExpression.cpp
@@ -93,6 +93,8 @@ static DescVector getDescriptions() {
   Descriptions[DW_OP_implicit_value] =
       Desc(Op::Dwarf3, Op::SizeLEB, Op::SizeBlock);
   Descriptions[DW_OP_stack_value] = Desc(Op::Dwarf3);
+  Descriptions[DW_OP_WASM_location] =
+      Desc(Op::Dwarf4, Op::SizeLEB, Op::SignedSizeLEB);
   Descriptions[DW_OP_GNU_push_tls_address] = Desc(Op::Dwarf3);
   Descriptions[DW_OP_addrx] = Desc(Op::Dwarf4, Op::SizeLEB);
   Descriptions[DW_OP_GNU_addr_index] = Desc(Op::Dwarf4, Op::SizeLEB);

--- a/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.h
+++ b/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.h
@@ -45,6 +45,12 @@ public:
 
   unsigned getFrameRegister(const MachineFunction &MF) const override;
 
+  FrameBaseLocation getFrameBaseLocation(const MachineFunction &MF) const override {
+    FrameBaseLocation Loc;
+    Loc.Kind = FrameBaseLocation::CFA;
+    return Loc;
+  }
+
   ManagedStringPool *getStrPool() const {
     return const_cast<ManagedStringPool *>(&ManagedStrPool);
   }

--- a/llvm/lib/Target/WebAssembly/WebAssembly.h
+++ b/llvm/lib/Target/WebAssembly/WebAssembly.h
@@ -82,6 +82,10 @@ void initializeWebAssemblyRegNumberingPass(PassRegistry &);
 void initializeWebAssemblyPeepholePass(PassRegistry &);
 void initializeWebAssemblyCallIndirectFixupPass(PassRegistry &);
 
+namespace WebAssembly {
+enum TargetIndex { TI_LOCAL_START, TI_GLOBAL_START, TI_OPERAND_STACK_START };
+} // end namespace WebAssembly
+
 } // end namespace llvm
 
 #endif

--- a/llvm/lib/Target/WebAssembly/WebAssemblyDebugValueManager.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyDebugValueManager.cpp
@@ -12,6 +12,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "WebAssembly.h"
 #include "WebAssemblyDebugValueManager.h"
 #include "WebAssemblyMachineFunctionInfo.h"
 #include "llvm/CodeGen/MachineInstr.h"
@@ -42,5 +43,12 @@ void WebAssemblyDebugValueManager::clone(MachineInstr *Insert,
     MachineInstr *Clone = MF->CloneMachineInstr(DBI);
     Clone->getOperand(0).setReg(NewReg);
     MBB->insert(Insert, Clone);
+  }
+}
+
+void WebAssemblyDebugValueManager::replaceWithLocal(unsigned LocalId) {
+  for (auto *DBI : DbgValues) {
+    MachineOperand &Op = DBI->getOperand(0);
+    Op.ChangeToTargetIndex(llvm::WebAssembly::TI_LOCAL_START, LocalId);
   }
 }

--- a/llvm/lib/Target/WebAssembly/WebAssemblyDebugValueManager.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyDebugValueManager.h
@@ -31,6 +31,7 @@ public:
   void move(MachineInstr *Insert);
   void updateReg(unsigned Reg);
   void clone(MachineInstr *Insert, unsigned NewReg);
+  void replaceWithLocal(unsigned LocalId);
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/WebAssembly/WebAssemblyExplicitLocals.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyExplicitLocals.cpp
@@ -386,6 +386,13 @@ bool WebAssemblyExplicitLocals::runOnMachineFunction(MachineFunction &MF) {
     Changed = true;
   }
 
+  {
+    auto RL = Reg2Local.find(MFI.SPVReg);
+    if (RL != Reg2Local.end()) {
+      MFI.SPLocal = RL->second;
+    }
+  }
+
 #ifndef NDEBUG
   // Assert that all registers have been stackified at this point.
   for (const MachineBasicBlock &MBB : MF) {

--- a/llvm/lib/Target/WebAssembly/WebAssemblyExplicitLocals.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyExplicitLocals.cpp
@@ -18,6 +18,7 @@
 
 #include "MCTargetDesc/WebAssemblyMCTargetDesc.h"
 #include "WebAssembly.h"
+#include "WebAssemblyDebugValueManager.h"
 #include "WebAssemblyMachineFunctionInfo.h"
 #include "WebAssemblySubtarget.h"
 #include "WebAssemblyUtilities.h"
@@ -262,6 +263,8 @@ bool WebAssemblyExplicitLocals::runOnMachineFunction(MachineFunction &MF) {
             .addImm(LocalId)
             .addReg(MI.getOperand(2).getReg());
 
+        WebAssemblyDebugValueManager(&MI).replaceWithLocal(LocalId);
+
         MI.eraseFromParent();
         Changed = true;
         continue;
@@ -291,6 +294,9 @@ bool WebAssemblyExplicitLocals::runOnMachineFunction(MachineFunction &MF) {
           } else {
             unsigned LocalId = getLocalId(Reg2Local, CurLocal, OldReg);
             unsigned Opc = getSetLocalOpcode(RC);
+
+            WebAssemblyDebugValueManager(&MI).replaceWithLocal(LocalId);
+
             BuildMI(MBB, InsertPt, MI.getDebugLoc(), TII->get(Opc))
                 .addImm(LocalId)
                 .addReg(NewReg);

--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.cpp
@@ -15,6 +15,7 @@
 
 #include "WebAssemblyInstrInfo.h"
 #include "MCTargetDesc/WebAssemblyMCTargetDesc.h"
+#include "WebAssembly.h"
 #include "WebAssemblyMachineFunctionInfo.h"
 #include "WebAssemblySubtarget.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
@@ -197,4 +198,13 @@ bool WebAssemblyInstrInfo::reverseBranchCondition(
   assert(Cond.size() == 2 && "Expected a flag and a successor block");
   Cond.front() = MachineOperand::CreateImm(!Cond.front().getImm());
   return false;
+}
+
+ArrayRef<std::pair<int, const char *>>
+WebAssemblyInstrInfo::getSerializableTargetIndices() const {
+  static const std::pair<int, const char *> TargetIndices[] = {
+      {WebAssembly::TI_LOCAL_START, "wasm-local-start"},
+      {WebAssembly::TI_GLOBAL_START, "wasm-global-start"},
+      {WebAssembly::TI_OPERAND_STACK_START, "wasm-operator-stack-start"}};
+  return makeArrayRef(TargetIndices);
 }

--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.h
@@ -17,6 +17,7 @@
 #define LLVM_LIB_TARGET_WEBASSEMBLY_WEBASSEMBLYINSTRINFO_H
 
 #include "WebAssemblyRegisterInfo.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/CodeGen/TargetInstrInfo.h"
 
 #define GET_INSTRINFO_HEADER
@@ -56,6 +57,9 @@ public:
                         int *BytesAdded = nullptr) const override;
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;
+
+  ArrayRef<std::pair<int, const char *>>
+  getSerializableTargetIndices() const override;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/WebAssembly/WebAssemblyMachineFunctionInfo.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyMachineFunctionInfo.h
@@ -53,7 +53,7 @@ class WebAssemblyFunctionInfo final : public MachineFunctionInfo {
   unsigned BasePtrVreg = -1U;
 
 public:
-  explicit WebAssemblyFunctionInfo(MachineFunction &MF) : MF(MF) {}
+  explicit WebAssemblyFunctionInfo(MachineFunction &MF) : MF(MF), SPVReg(WebAssembly::NoRegister) {}
   ~WebAssemblyFunctionInfo() override;
 
   void addParam(MVT VT) { Params.push_back(VT); }
@@ -118,6 +118,9 @@ public:
     assert(Reg & INT32_MIN);
     return Reg & INT32_MAX;
   }
+
+  unsigned SPVReg;
+  unsigned SPLocal;
 };
 
 void ComputeLegalValueVTs(const Function &F, const TargetMachine &TM, Type *Ty,

--- a/llvm/lib/Target/WebAssembly/WebAssemblyRegisterInfo.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyRegisterInfo.cpp
@@ -138,6 +138,16 @@ WebAssemblyRegisterInfo::getFrameRegister(const MachineFunction &MF) const {
   return Regs[TFI->hasFP(MF)][TT.isArch64Bit()];
 }
 
+FrameBaseLocation
+WebAssemblyRegisterInfo::getFrameBaseLocation(const MachineFunction &MF) const {
+  const WebAssemblyFunctionInfo &MFI = *MF.getInfo<WebAssemblyFunctionInfo>();
+  FrameBaseLocation Loc;
+  Loc.Kind = FrameBaseLocation::TargetIndex;
+  signed Local = MFI.SPVReg != WebAssembly::NoRegister ? MFI.SPLocal : -1;
+  Loc.TI = {0, Local};
+  return Loc;
+}
+
 const TargetRegisterClass *
 WebAssemblyRegisterInfo::getPointerRegClass(const MachineFunction &MF,
                                             unsigned Kind) const {

--- a/llvm/lib/Target/WebAssembly/WebAssemblyRegisterInfo.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyRegisterInfo.h
@@ -42,6 +42,8 @@ public:
   // Debug information queries.
   unsigned getFrameRegister(const MachineFunction &MF) const override;
 
+  FrameBaseLocation getFrameBaseLocation(const MachineFunction &MF) const override;
+
   const TargetRegisterClass *
   getPointerRegClass(const MachineFunction &MF,
                      unsigned Kind = 0) const override;

--- a/llvm/lib/Target/WebAssembly/WebAssemblyReplacePhysRegs.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyReplacePhysRegs.cpp
@@ -89,8 +89,13 @@ bool WebAssemblyReplacePhysRegs::runOnMachineFunction(MachineFunction &MF) {
     for (auto I = MRI.reg_begin(PReg), E = MRI.reg_end(); I != E;) {
       MachineOperand &MO = *I++;
       if (!MO.isImplicit()) {
-        if (VReg == WebAssembly::NoRegister)
+        if (VReg == WebAssembly::NoRegister) {
           VReg = MRI.createVirtualRegister(RC);
+          if (PReg == WebAssembly::SP32) {
+            WebAssemblyFunctionInfo &MFI = *MF.getInfo<WebAssemblyFunctionInfo>();
+            MFI.SPVReg = VReg;
+          }
+        }
         MO.setReg(VReg);
         if (MO.getParent()->isDebugValue())
           MO.setIsDebug();

--- a/llvm/test/DebugInfo/WebAssembly/dbg-value-ti.ll
+++ b/llvm/test/DebugInfo/WebAssembly/dbg-value-ti.ll
@@ -1,0 +1,74 @@
+; RUN: llc < %s -stop-after=wasm-explicit-locals | FileCheck %s
+
+; Checks if DBG_VALUEs that correspond to new `local.{tee,set}` are
+; using `target-index(wasm-local-start)` operands.
+
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target triple = "wasm32-unknown-unknown-wasm"
+
+define hidden i32 @fib(i32 %n) local_unnamed_addr #0 !dbg !7 {
+; CHECK: body:
+entry:
+
+; CHECK: %[[REG1:.*]]:i32 = CONST_I32 1,
+; CHECK: LOCAL_SET_I32 [[LOOP_LOCAL:.*]], %[[REG1]],
+; CHECK: DBG_VALUE 1, $noreg,
+  call void @llvm.dbg.value(metadata i32 1, metadata !16, metadata !DIExpression()), !dbg !19
+  %cmp8 = icmp sgt i32 %n, 0, !dbg !21
+  br i1 %cmp8, label %for.body, label %for.end, !dbg !24
+
+for.body:                                         ; preds = %entry, %for.body
+  %b.011 = phi i32 [ %add, %for.body ], [ 1, %entry ]
+  %a.010 = phi i32 [ %b.011, %for.body ], [ 0, %entry ]
+  %i.09 = phi i32 [ %inc, %for.body ], [ 0, %entry ]
+
+; CHECK: %[[REG2:.*]]:i32 = LOCAL_GET_I32 [[LOOP_LOCAL]],
+; CHECK: %[[REG3:.*]]:i32 = LOCAL_TEE_I32 [[TMP_LOCAL:.*]], %[[REG2]],
+; CHECK: DBG_VALUE target-index(wasm-local-start) + [[TMP_LOCAL]], $noreg,
+  call void @llvm.dbg.value(metadata i32 %b.011, metadata !16, metadata !DIExpression()), !dbg !19
+
+; CHECK: %[[REG4:.*]]:i32 = nsw ADD_I32
+; CHECK: LOCAL_SET_I32 [[LOOP_LOCAL]], %[[REG4]],
+; CHECK: DBG_VALUE target-index(wasm-local-start) + [[LOOP_LOCAL]], $noreg,
+  %add = add nsw i32 %b.011, %a.010, !dbg !26
+  %inc = add nuw nsw i32 %i.09, 1, !dbg !28
+  call void @llvm.dbg.value(metadata i32 %add, metadata !16, metadata !DIExpression()), !dbg !19
+  %exitcond = icmp eq i32 %inc, %n, !dbg !21
+  br i1 %exitcond, label %for.end, label %for.body, !dbg !24, !llvm.loop !29
+
+for.end:                                          ; preds = %for.body, %entry
+  %b.0.lcssa = phi i32 [ 1, %entry ], [ %add, %for.body ], !dbg !31
+  call void @llvm.dbg.value(metadata i32 %b.0.lcssa, metadata !16, metadata !DIExpression()), !dbg !19
+  ret i32 %b.0.lcssa, !dbg !32
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata) #1
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!4}
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 8.0.0 ", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: None)
+!1 = !DIFile(filename: "<unknown>", directory: "")
+!2 = !{}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!7 = distinct !DISubprogram(name: "fib", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(types: !9)
+!9 = !{!10, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!16}
+!16 = !DILocalVariable(name: "b", scope: !7, file: !1, line: 2, type: !10)
+!17 = !DILocation(line: 1, column: 13, scope: !7)
+!18 = !DILocation(line: 2, column: 13, scope: !7)
+!19 = !DILocation(line: 2, column: 20, scope: !7)
+!20 = !DILocation(line: 2, column: 7, scope: !7)
+!21 = !DILocation(line: 3, column: 17, scope: !22)
+!22 = distinct !DILexicalBlock(scope: !23, file: !1, line: 3, column: 3)
+!23 = distinct !DILexicalBlock(scope: !7, file: !1, line: 3, column: 3)
+!24 = !DILocation(line: 3, column: 3, scope: !23)
+!25 = !DILocation(line: 2, column: 10, scope: !7)
+!26 = !DILocation(line: 6, column: 7, scope: !27)
+!27 = distinct !DILexicalBlock(scope: !22, file: !1, line: 3, column: 27)
+!28 = !DILocation(line: 3, column: 23, scope: !22)
+!29 = distinct !{!29, !24, !30}
+!30 = !DILocation(line: 7, column: 3, scope: !23)
+!31 = !DILocation(line: 0, scope: !7)
+!32 = !DILocation(line: 8, column: 3, scope: !7)


### PR DESCRIPTION
(Rebase and duplicate of https://github.com/rust-lang/llvm/pull/134)

This is an experimental patch set for LLVM to emit more accurate DWARF information for the WebAssembly: it extends DWARF expression language to express locals/globals locations (via
target-index operands atm).

    * The WebAssemblyExplicitLocals can replace virtual registers to target-index operand type at the time when WebAssembly backend introduces {set,tee}_local instead of corresponding virtual registers.

    * The subroutine frame base address can contain WebAssembly location (e.g. local)

See also https://github.com/rust-lang/llvm/pull/134#issuecomment-454090057
