### PR TITLE
Provide lprofGetHostName for all windows environments

### DIFF
--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -81,7 +81,7 @@ void *lprofPtrFetchAdd(void **Mem, long ByteIncr) {
 
 #endif
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 COMPILER_RT_VISIBILITY int lprofGetHostName(char *Name, int Len) {
   WCHAR Buffer[COMPILER_RT_MAX_HOSTLEN];
   DWORD BufferSize = sizeof(Buffer);


### PR DESCRIPTION
Moved from https://github.com/rust-lang/compiler-rt/pull/38

cc @alexcrichton 