### PR TITLE
[X86] Combine fminnum/fmaxnum with non-nan operand to fmin/fmax

### DIFF
--- a/llvm/test/CodeGen/X86/extract-fp.ll
+++ b/llvm/test/CodeGen/X86/extract-fp.ll
@@ -84,3 +84,39 @@ define float @ext_frem_v4f32_constant_op0(<4 x float> %x) {
   ret float %ext
 }
 
+define float @ext_maxnum_v4f32(<4 x float> %x) nounwind {
+; CHECK-LABEL: ext_maxnum_v4f32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    movhlps {{.*#+}} xmm0 = xmm0[1,1]
+; CHECK-NEXT:    maxss {{.*}}(%rip), %xmm0
+; CHECK-NEXT:    retq
+  %v = call <4 x float> @llvm.maxnum.v4f32(<4 x float> %x, <4 x float> <float 0.0, float 1.0, float 2.0, float 3.0>)
+  %r = extractelement <4 x float> %v, i32 2
+  ret float %r
+}
+
+define double @ext_minnum_v2f64(<2 x double> %x) nounwind {
+; CHECK-LABEL: ext_minnum_v2f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    unpckhpd {{.*#+}} xmm0 = xmm0[1,1]
+; CHECK-NEXT:    minsd {{.*}}(%rip), %xmm0
+; CHECK-NEXT:    retq
+  %v = call <2 x double> @llvm.minnum.v2f64(<2 x double> <double 0.0, double 1.0>, <2 x double> %x)
+  %r = extractelement <2 x double> %v, i32 1
+  ret double %r
+}
+
+;define double @ext_maximum_v4f64(<2 x double> %x) nounwind {
+;  %v = call <2 x double> @llvm.maximum.v2f64(<2 x double> %x, <2 x double> <double 42.0, double 43.0>)
+;  %r = extractelement <2 x double> %v, i32 1
+;  ret double %r
+;}
+
+;define float @ext_minimum_v4f32(<4 x float> %x) nounwind {
+;  %v = call <4 x float> @llvm.minimum.v4f32(<4 x float> %x, <4 x float> <float 0.0, float 1.0, float 2.0, float 42.0>)
+;  %r = extractelement <4 x float> %v, i32 1
+;  ret float %r
+;}
+
+declare <4 x float> @llvm.maxnum.v4f32(<4 x float>, <4 x float>)
+declare <2 x double> @llvm.minnum.v2f64(<2 x double>, <2 x double>)

--- a/llvm/test/CodeGen/X86/fmaxnum.ll
+++ b/llvm/test/CodeGen/X86/fmaxnum.ll
@@ -349,5 +349,33 @@ define <2 x double> @maxnum_intrinsic_nnan_attr_f64(<2 x double> %a, <2 x double
   ret <2 x double> %r
 }
 
+define float @test_maxnum_const_op1(float %x) {
+; SSE-LABEL: test_maxnum_const_op1:
+; SSE:       # %bb.0:
+; SSE-NEXT:    maxss {{.*}}(%rip), %xmm0
+; SSE-NEXT:    retq
+;
+; AVX-LABEL: test_maxnum_const_op1:
+; AVX:       # %bb.0:
+; AVX-NEXT:    vmaxss {{.*}}(%rip), %xmm0, %xmm0
+; AVX-NEXT:    retq
+  %r = call float @llvm.maxnum.f32(float 1.0, float %x)
+  ret float %r
+}
+
+define float @test_maxnum_const_op2(float %x) {
+; SSE-LABEL: test_maxnum_const_op2:
+; SSE:       # %bb.0:
+; SSE-NEXT:    maxss {{.*}}(%rip), %xmm0
+; SSE-NEXT:    retq
+;
+; AVX-LABEL: test_maxnum_const_op2:
+; AVX:       # %bb.0:
+; AVX-NEXT:    vmaxss {{.*}}(%rip), %xmm0, %xmm0
+; AVX-NEXT:    retq
+  %r = call float @llvm.maxnum.f32(float %x, float 1.0)
+  ret float %r
+}
+
 attributes #0 = { "no-nans-fp-math"="true" }
 

--- a/llvm/test/CodeGen/X86/fminnum.ll
+++ b/llvm/test/CodeGen/X86/fminnum.ll
@@ -341,5 +341,33 @@ define <4 x float> @minnum_intrinsic_nnan_attr_v4f32(<4 x float> %a, <4 x float>
   ret <4 x float> %r
 }
 
+define float @test_minnum_const_op1(float %x) {
+; SSE-LABEL: test_minnum_const_op1:
+; SSE:       # %bb.0:
+; SSE-NEXT:    minss {{.*}}(%rip), %xmm0
+; SSE-NEXT:    retq
+;
+; AVX-LABEL: test_minnum_const_op1:
+; AVX:       # %bb.0:
+; AVX-NEXT:    vminss {{.*}}(%rip), %xmm0, %xmm0
+; AVX-NEXT:    retq
+  %r = call float @llvm.minnum.f32(float 1.0, float %x)
+  ret float %r
+}
+
+define float @test_minnum_const_op2(float %x) {
+; SSE-LABEL: test_minnum_const_op2:
+; SSE:       # %bb.0:
+; SSE-NEXT:    minss {{.*}}(%rip), %xmm0
+; SSE-NEXT:    retq
+;
+; AVX-LABEL: test_minnum_const_op2:
+; AVX:       # %bb.0:
+; AVX-NEXT:    vminss {{.*}}(%rip), %xmm0, %xmm0
+; AVX-NEXT:    retq
+  %r = call float @llvm.minnum.f32(float %x, float 1.0)
+  ret float %r
+}
+
 attributes #0 = { "no-nans-fp-math"="true" }
 


### PR DESCRIPTION
Cherry-picks https://github.com/llvm/llvm-project/commit/d87eceda0e6d5de6b2d58430a0124b6f7428695d as per https://github.com/rust-lang/rust/issues/18384#issuecomment-495932765. There were some conflicts, but the essence (i.e. the changes to `X86ISelLowering.cpp`) is the same.