### PR TITLE
Unlock ThinLTO for RISC-V

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1086,6 +1086,9 @@ static uint8_t getBitcodeMachineKind(StringRef Path, const Triple &T) {
   case Triple::ppc64:
   case Triple::ppc64le:
     return EM_PPC64;
+  case Triple::riscv32:
+  case Triple::riscv64:
+    return EM_RISCV;
   case Triple::x86:
     return T.isOSIAMCU() ? EM_IAMCU : EM_386;
   case Triple::x86_64:


### PR DESCRIPTION
This patch is taken from [differential revision D52165](https://reviews.llvm.org/D52165). It isn't present in LLVM master, but it's quite useful and simple.

Without this patch rust-lld fails with `could not infer e_machine from bitcode target triple riscv32` trying to link with bitcode object file.

This patch allows [using inlined assembly operations](https://github.com/rust-embedded/cortex-m/issues/139) on stable Rust with the help of ThinLTO.