### PR TITLE
Unlock ThinLTO for RISC-V (second try)

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1086,6 +1086,9 @@ static uint8_t getBitcodeMachineKind(StringRef Path, const Triple &T) {
   case Triple::ppc64:
   case Triple::ppc64le:
     return EM_PPC64;
+  case Triple::riscv32:
+  case Triple::riscv64:
+    return EM_RISCV;
   case Triple::x86:
     return T.isOSIAMCU() ? EM_IAMCU : EM_386;
   case Triple::x86_64:

--- a/lld/test/ELF/lto/riscv32.ll
+++ b/lld/test/ELF/lto/riscv32.ll
@@ -1,0 +1,10 @@
+; REQUIRES: riscv
+
+; RUN: llvm-as %s -o %t.o
+; RUN: ld.lld %t.o -o %t
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S128"
+target triple = "riscv32-unknown-elf"
+
+define void @f() {
+  ret void
+}

--- a/lld/test/ELF/lto/riscv64.ll
+++ b/lld/test/ELF/lto/riscv64.ll
@@ -1,0 +1,10 @@
+; REQUIRES: riscv
+
+; RUN: llvm-as %s -o %t.o
+; RUN: ld.lld %t.o -o %t
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"
+target triple = "riscv64-unknown-elf"
+
+define void @f() {
+  ret void
+}


### PR DESCRIPTION
This is a cherry-pick of the following commit:
[[ELF][RISCV] Support RISC-V in getBitcodeMachineKind](https://github.com/llvm/llvm-project/commit/eb9bc382760532cb7f0acf14e9c08b014a6f2c9e)

Without this patch rust-lld fails with `could not infer e_machine from bitcode target triple riscv32` trying to link with bitcode object file.

This patch allows [using inlined assembly operations](https://github.com/rust-embedded/cortex-m/issues/139) on stable Rust with the help of ThinLTO.