### PR TITLE
Update to LLVM 9

### DIFF
--- a/compiler-rt/lib/asan/asan_linux.cc
+++ b/compiler-rt/lib/asan/asan_linux.cc
@@ -214,7 +214,7 @@ void AsanCheckIncompatibleRT() {
       // the functions in dynamic ASan runtime instead of the functions in
       // system libraries, causing crashes later in ASan initialization.
       MemoryMappingLayout proc_maps(/*cache_enabled*/true);
-      char filename[PATH_MAX];
+      char filename[4096];
       MemoryMappedSegment segment(filename, sizeof(filename));
       while (proc_maps.Next(&segment)) {
         if (IsDynamicRTName(segment.filename)) {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cc
@@ -698,12 +698,8 @@ u32 GetNumberOfCPUs() {
   }
   internal_close(fd);
   return n_cpus;
-#elif SANITIZER_SOLARIS
-  return sysconf(_SC_NPROCESSORS_ONLN);
 #else
-  cpu_set_t CPUs;
-  CHECK_EQ(sched_getaffinity(0, sizeof(cpu_set_t), &CPUs), 0);
-  return CPU_COUNT(&CPUs);
+  return sysconf(_SC_NPROCESSORS_ONLN);
 #endif
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
@@ -106,6 +106,7 @@ typedef struct user_fpregs elf_fpregset_t;
 #endif
 
 #if SANITIZER_LINUX && !SANITIZER_ANDROID
+#include <stdio.h>
 #include <glob.h>
 #include <obstack.h>
 #include <mqueue.h>
@@ -1010,9 +1011,9 @@ CHECK_SIZE_AND_OFFSET(cmsghdr, cmsg_type);
 #endif
 
 #if SANITIZER_LINUX && (__ANDROID_API__ >= 21 || __GLIBC_PREREQ (2, 14))
-CHECK_TYPE_SIZE(mmsghdr);
-CHECK_SIZE_AND_OFFSET(mmsghdr, msg_hdr);
-CHECK_SIZE_AND_OFFSET(mmsghdr, msg_len);
+// CHECK_TYPE_SIZE(mmsghdr);
+// CHECK_SIZE_AND_OFFSET(mmsghdr, msg_hdr);
+// CHECK_SIZE_AND_OFFSET(mmsghdr, msg_len);
 #endif
 
 COMPILER_CHECK(sizeof(__sanitizer_dirent) <= sizeof(dirent));

--- a/compiler-rt/lib/sanitizer_common/sanitizer_posix.cc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_posix.cc
@@ -338,6 +338,9 @@ bool ShouldMockFailureToOpen(const char *path) {
 }
 
 #if SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_GO
+# ifndef O_CLOEXEC
+#  define O_CLOEXEC 0
+# endif
 int GetNamedMappingFd(const char *name, uptr size, int *flags) {
   if (!common_flags()->decorate_proc_maps || !name)
     return -1;

--- a/compiler-rt/lib/xray/xray_x86_64.cc
+++ b/compiler-rt/lib/xray/xray_x86_64.cc
@@ -49,6 +49,9 @@ retryingReadSome(int Fd, char *Begin, char *End) XRAY_NEVER_INSTRUMENT {
   return std::make_pair(TotalBytesRead, true);
 }
 
+#ifndef O_CLOEXEC
+# define O_CLOEXEC 0
+#endif
 static bool readValueFromFile(const char *Filename,
                               long long *Value) XRAY_NEVER_INSTRUMENT {
   int Fd = open(Filename, O_RDONLY | O_CLOEXEC);

--- a/lld/CMakeLists.txt
+++ b/lld/CMakeLists.txt
@@ -210,6 +210,19 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
     )
 endif()
 
+if (MSVC)
+  FOREACH(flag
+      CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_RELWITHDEBINFO
+      CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_DEBUG_INIT
+      CMAKE_CXX_FLAGS_RELEASE  CMAKE_CXX_FLAGS_RELWITHDEBINFO
+      CMAKE_CXX_FLAGS_DEBUG  CMAKE_CXX_FLAGS_DEBUG_INIT)
+      if (MSVC)
+          STRING(REPLACE "/MD"  "/MT" "${flag}" "${${flag}}")
+          SET("${flag}" "${${flag}}")
+      endif (MSVC)
+  ENDFOREACH()
+endif()
+
 add_subdirectory(Common)
 add_subdirectory(lib)
 add_subdirectory(tools/lld)

--- a/llvm/cmake/modules/CheckAtomic.cmake
+++ b/llvm/cmake/modules/CheckAtomic.cmake
@@ -62,19 +62,20 @@ else()
   check_working_cxx_atomics64(HAVE_CXX_ATOMICS64_WITHOUT_LIB)
 endif()
 
-# If not, check if the library exists, and atomics work with it.
-if(NOT HAVE_CXX_ATOMICS64_WITHOUT_LIB)
-  check_library_exists(atomic __atomic_load_8 "" HAVE_CXX_LIBATOMICS64)
-  if(HAVE_CXX_LIBATOMICS64)
-    list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
-    check_working_cxx_atomics64(HAVE_CXX_ATOMICS64_WITH_LIB)
-    if (NOT HAVE_CXX_ATOMICS64_WITH_LIB)
-      message(FATAL_ERROR "Host compiler must support std::atomic!")
-    endif()
-  else()
-    message(FATAL_ERROR "Host compiler appears to require libatomic, but cannot find it.")
-  endif()
-endif()
+# RUST-SPECIFIC - commented out, see commit message
+# # If not, check if the library exists, and atomics work with it.
+# if(NOT HAVE_CXX_ATOMICS64_WITHOUT_LIB)
+#   check_library_exists(atomic __atomic_load_8 "" HAVE_CXX_LIBATOMICS64)
+#   if(HAVE_CXX_LIBATOMICS64)
+#     list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
+#     check_working_cxx_atomics64(HAVE_CXX_ATOMICS64_WITH_LIB)
+#     if (NOT HAVE_CXX_ATOMICS64_WITH_LIB)
+#       message(FATAL_ERROR "Host compiler must support std::atomic!")
+#     endif()
+#   else()
+#     message(FATAL_ERROR "Host compiler appears to require libatomic, but cannot find it.")
+#   endif()
+# endif()
 
 ## TODO: This define is only used for the legacy atomic operations in
 ## llvm's Atomic.h, which should be replaced.  Other code simply

--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.def
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.def
@@ -355,6 +355,16 @@ TLI_DEFINE_STRING_INTERNAL("__powf_finite")
 /// long double __powl_finite(long double x, long double y);
 TLI_DEFINE_ENUM_INTERNAL(powl_finite)
 TLI_DEFINE_STRING_INTERNAL("__powl_finite")
+
+TLI_DEFINE_ENUM_INTERNAL(rust_alloc)
+TLI_DEFINE_STRING_INTERNAL("__rust_alloc")
+
+TLI_DEFINE_ENUM_INTERNAL(rust_dealloc)
+TLI_DEFINE_STRING_INTERNAL("__rust_dealloc")
+
+TLI_DEFINE_ENUM_INTERNAL(rust_realloc)
+TLI_DEFINE_STRING_INTERNAL("__rust_realloc")
+
 /// double __sincospi_stret(double x);
 TLI_DEFINE_ENUM_INTERNAL(sincospi_stret)
 TLI_DEFINE_STRING_INTERNAL("__sincospi_stret")

--- a/llvm/include/llvm/MC/MCSubtargetInfo.h
+++ b/llvm/include/llvm/MC/MCSubtargetInfo.h
@@ -221,6 +221,14 @@ public:
     auto Found = std::lower_bound(ProcDesc.begin(), ProcDesc.end(), CPU);
     return Found != ProcDesc.end() && StringRef(Found->Key) == CPU;
   }
+
+  ArrayRef<SubtargetSubTypeKV> getCPUTable() const {
+    return ProcDesc;
+  }
+
+  ArrayRef<SubtargetFeatureKV> getFeatureTable() const {
+    return ProcFeatures;
+  }
 };
 
 } // end namespace llvm

--- a/llvm/lib/Analysis/MemoryBuiltins.cpp
+++ b/llvm/lib/Analysis/MemoryBuiltins.cpp
@@ -104,7 +104,10 @@ static const std::pair<LibFunc, AllocFnsTy> AllocationFnData[] = {
   {LibFunc_realloc,             {ReallocLike, 2, 1,  -1}},
   {LibFunc_reallocf,            {ReallocLike, 2, 1,  -1}},
   {LibFunc_strdup,              {StrDupLike,  1, -1, -1}},
-  {LibFunc_strndup,             {StrDupLike,  2, 1,  -1}}
+  {LibFunc_strndup,             {StrDupLike,  2, 1,  -1}},
+
+  {LibFunc_rust_alloc,         {MallocLike,  2, 0,  -1}},
+  {LibFunc_rust_realloc,       {ReallocLike,  4, 3,  -1}},
   // TODO: Handle "int posix_memalign(void **, size_t, size_t)"
 };
 
@@ -398,7 +401,8 @@ const CallInst *llvm::isFreeCall(const Value *I, const TargetLibraryInfo *TLI) {
            TLIFn == LibFunc_msvc_delete_array_ptr64_nothrow)   // delete[](void*, nothrow)
     ExpectedNumParams = 2;
   else if (TLIFn == LibFunc_ZdaPvSt11align_val_tRKSt9nothrow_t || // delete(void*, align_val_t, nothrow)
-           TLIFn == LibFunc_ZdlPvSt11align_val_tRKSt9nothrow_t) // delete[](void*, align_val_t, nothrow)
+           TLIFn == LibFunc_ZdlPvSt11align_val_tRKSt9nothrow_t || // delete[](void*, align_val_t, nothrow)
+           TLIFn == LibFunc_rust_dealloc)
     ExpectedNumParams = 3;
   else
     return nullptr;

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -1480,6 +1480,28 @@ bool TargetLibraryInfoImpl::isValidProtoForLibFunc(const FunctionType &FTy,
     else
       return false;
   }
+
+  case LibFunc_rust_alloc:
+    return (NumParams == 3 && FTy.getReturnType()->isPointerTy() &&
+            FTy.getParamType(0)->isIntegerTy() &&
+            FTy.getParamType(1)->isIntegerTy() &&
+            FTy.getParamType(2)->isPointerTy());
+
+  case LibFunc_rust_dealloc:
+    return (NumParams == 3 && FTy.getReturnType()->isVoidTy() &&
+            FTy.getParamType(0)->isPointerTy() &&
+            FTy.getParamType(1)->isIntegerTy() &&
+            FTy.getParamType(2)->isIntegerTy());
+
+  case LibFunc_rust_realloc:
+    return (NumParams == 6 && FTy.getReturnType()->isPointerTy() &&
+            FTy.getParamType(0)->isPointerTy() &&
+            FTy.getParamType(1)->isIntegerTy() &&
+            FTy.getParamType(2)->isIntegerTy() &&
+            FTy.getParamType(3)->isIntegerTy() &&
+            FTy.getParamType(4)->isIntegerTy() &&
+            FTy.getParamType(5)->isPointerTy());
+
   case LibFunc::NumLibFuncs:
     break;
   }

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RTDyldMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RTDyldMemoryManager.cpp
@@ -243,9 +243,9 @@ RTDyldMemoryManager::getSymbolAddressInProcess(const std::string &Name) {
   if (Name == "stat") return (uint64_t)&stat;
   if (Name == "fstat") return (uint64_t)&fstat;
   if (Name == "lstat") return (uint64_t)&lstat;
-  if (Name == "stat64") return (uint64_t)&stat64;
-  if (Name == "fstat64") return (uint64_t)&fstat64;
-  if (Name == "lstat64") return (uint64_t)&lstat64;
+  // if (Name == "stat64") return (uint64_t)&stat64;
+  // if (Name == "fstat64") return (uint64_t)&fstat64;
+  // if (Name == "lstat64") return (uint64_t)&lstat64;
   if (Name == "atexit") return (uint64_t)&atexit;
   if (Name == "mknod") return (uint64_t)&mknod;
 

--- a/llvm/lib/Support/Unix/Program.inc
+++ b/llvm/lib/Support/Unix/Program.inc
@@ -462,7 +462,7 @@ bool llvm::sys::commandLineFitsWithinSystemLimits(StringRef Program,
   static long ArgMax = sysconf(_SC_ARG_MAX);
   // POSIX requires that _POSIX_ARG_MAX is 4096, which is the lowest possible
   // value for ARG_MAX on a POSIX compliant system.
-  static long ArgMin = _POSIX_ARG_MAX;
+  static long ArgMin = 4096;
 
   // This the same baseline used by xargs.
   long EffectiveArgMax = 128 * 1024;

--- a/llvm/test/CodeGen/X86/tls-no-plt.ll
+++ b/llvm/test/CodeGen/X86/tls-no-plt.ll
@@ -1,5 +1,10 @@
-; RUN: llc < %s -mtriple=i386-linux-musl -relocation-model=pic | FileCheck --check-prefixes=CHECK,X86 %s
-; RUN: llc < %s -mtriple=x86_64-linux-musl -relocation-model=pic | FileCheck --check-prefixes=CHECK,X64 %s
+; RUN: llc < %s -mtriple=i386-linux-musl -relocation-model=pic -relax-elf-relocations=true | FileCheck --check-prefixes=CHECK,X86 %s
+; RUN: llc < %s -mtriple=x86_64-linux-musl -relocation-model=pic -relax-elf-relocations=true | FileCheck --check-prefixes=CHECK,X64 %s
+
+;; If GOTPCRELX is disabled, don't use GOT for __tls_get_addr to work around
+;; a ld.bfd bug (binutils PR24784).
+; RUN: llc < %s -mtriple=i386-linux-musl -relocation-model=pic | FileCheck --check-prefixes=CHECK,X86-PLT %s
+; RUN: llc < %s -mtriple=x86_64-linux-musl -relocation-model=pic | FileCheck --check-prefixes=CHECK,X64-PLT %s
 
 @gd = thread_local global i32 0
 @ld = internal thread_local global i32 0
@@ -9,9 +14,11 @@ entry:
 ; CHECK-LABEL: get_gd:
 ; X86: leal gd@TLSGD(%ebx), %eax
 ; X86: calll *___tls_get_addr@GOT(%ebx)
+; X86-PLT: calll ___tls_get_addr@PLT
 
 ; X64: leaq gd@TLSGD(%rip), %rdi
 ; X64: callq *__tls_get_addr@GOTPCREL(%rip)
+; X64-PLT: callq __tls_get_addr@PLT
   ret i32* @gd
 }
 
@@ -20,9 +27,11 @@ define i32* @get_ld() {
 ; CHECK-LABEL: get_ld:
 ; X86: leal ld@TLSLDM(%ebx), %eax
 ; X86: calll *___tls_get_addr@GOT(%ebx)
+; X86-PLT: calll ___tls_get_addr@PLT
 
 ; X64: leaq ld@TLSLD(%rip), %rdi
 ; X64: callq *__tls_get_addr@GOTPCREL(%rip)
+; X64-PLT: callq __tls_get_addr@PLT
   ret i32* @ld
 }
 


### PR DESCRIPTION
LLVM 9 will be branched soon, so it's time to work on an upgrade... This is a rebase onto https://github.com/rust-lang/llvm-project/commit/bd791b57f8d76fa99048d8d605b7b749bb8c83fc. Notes:
 * I've dropped the patch from #2 due to non-trivial conflicts.
 * Dropped Rust LLDB patches because they are unused and rebasing them is pretty hard. https://github.com/nikic/llvm-project/commits/llvm-9-lldb has a rebase and partial fixup, if we want to bring them back.
 * Applied https://github.com/llvm/llvm-project/commit/f9ca13cb5f05f2a1acce223e794444078584ef0d to avoid bfd linker errors due to GOT tls_get_addr.
 * Applied https://github.com/llvm/llvm-project/commit/5ca39e828c893f6fa823ea0cc5f2a8b9e19cecc7 to partially fix an SLP vectorizer perf regression.