### PR TITLE
Comment out __builtin_available() use

### DIFF
--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1153,7 +1153,7 @@ namespace fs {
 /// implementation.
 std::error_code copy_file(const Twine &From, const Twine &To) {
   uint32_t Flag = COPYFILE_DATA;
-#if __has_builtin(__builtin_available)
+#if 0 && __has_builtin(__builtin_available)
   if (__builtin_available(macos 10.12, *)) {
     bool IsSymlink;
     if (std::error_code Error = is_symlink_file(From, IsSymlink))


### PR DESCRIPTION
__builtin_available() pulls in __isOSVersionAtLeast() from
compiler-rt. Comment it out so we don't have to figure out how
to link in this symbol...

r? @alexcrichton 