### PR TITLE
Address non-determinism in DWARF

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyMachineFunctionInfo.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyMachineFunctionInfo.h
@@ -61,7 +61,7 @@ class WebAssemblyFunctionInfo final : public MachineFunctionInfo {
 
 public:
   explicit WebAssemblyFunctionInfo(MachineFunction &MF)
-      : MF(MF), SPVReg(WebAssembly::NoRegister) {}
+      : MF(MF), SPVReg(WebAssembly::NoRegister), SPLocal(-1) {}
   ~WebAssemblyFunctionInfo() override;
   void initializeBaseYamlFields(const yaml::WebAssemblyFunctionInfo &YamlMFI);
 


### PR DESCRIPTION
see https://github.com/rust-lang/llvm-project/pull/20/commits/c263ee986fc90d8413f444ced7610dfbdfe97be6#r344425408

> the effect is that SPLocal can remain uninitialized, which produces non-determinism

There can be issues with https://reviews.llvm.org/D69807, patching it quickly to avoid non-determinism.