### PR TITLE
[WebAssembly] Fix landingpad-only case in Emscripten EH

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
@@ -755,7 +755,6 @@ bool WebAssemblyLowerEmscriptenEHSjLj::runEHOnFunction(Function &F) {
     auto *II = dyn_cast<InvokeInst>(BB.getTerminator());
     if (!II)
       continue;
-    Changed = true;
     LandingPads.insert(II->getLandingPadInst());
     IRB.SetInsertPoint(II);
 
@@ -835,6 +834,7 @@ bool WebAssemblyLowerEmscriptenEHSjLj::runEHOnFunction(Function &F) {
     if (auto *LPI = dyn_cast<LandingPadInst>(I))
       LandingPads.insert(LPI);
   }
+  Changed = !LandingPads.empty();
 
   // Handle all the landingpad for this function together, as multiple invokes
   // may share a single lp

--- a/llvm/test/CodeGen/WebAssembly/lower-em-exceptions-lpad-only.ll
+++ b/llvm/test/CodeGen/WebAssembly/lower-em-exceptions-lpad-only.ll
@@ -1,0 +1,25 @@
+; RUN: opt < %s -wasm-lower-em-ehsjlj -S | FileCheck %s
+
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target triple = "wasm32-unknown-unknown"
+
+@_ZTIi = external constant i8*
+
+; Checks if a module that only contains a landingpad (and resume) but not an
+; invoke works correctly and does not crash.
+; CHECK-LABEL: @landingpad_only
+define void @landingpad_only() personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*) {
+entry:
+  br label %cont
+
+lpad:                                             ; preds = %entry
+  %0 = landingpad { i8*, i32 }
+          catch i8* bitcast (i8** @_ZTIi to i8*)
+          catch i8* null
+  resume { i8*, i32 } %0
+
+cont:
+  ret void
+}
+
+declare i32 @__gxx_personality_v0(...)


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/66308. Original commit message follows:

Summary:
Previously we didn't set `Changed` to true when there are only landing
pads but not invokes. This fixes it and we set `Changed` to true
whenever we have landing pads. (There can't be invokes without landing
pads, so that case is covered too)

The test case for this has to be a separate file because this pass is a
`ModulePass` and `Changed` is computed based on the whole module.

Reviewers: tlively

Subscribers: dschuff, sbc100, jgravelle-google, hiraditya, sunfish, llvm-commits

Tags: #llvm

Differential Revision: https://reviews.llvm.org/D72308