### PR TITLE
[MSP430] Allow msp430_intrcc functions to not have interrupt attribute.

### DIFF
--- a/llvm/test/CodeGen/MSP430/interrupt.ll
+++ b/llvm/test/CodeGen/MSP430/interrupt.ll
@@ -50,4 +50,13 @@ entry:
   ret void
 }
 
+; Functions without 'interrupt' attribute don't get a vector section.
+; CHECK-NOT: __interrupt_vector
+; CHECK-LABEL: NMI:
+; CHECK: reti
+define msp430_intrcc void @NMI() #1 {
+  ret void
+}
+
 attributes #0 = { noinline nounwind optnone "interrupt"="2" }
+attributes #1 = { noinline nounwind optnone }


### PR DESCRIPTION
Summary:
Useful in case you want to have control over interrupt vector generation.
For example in Rust language we have an arrangement where all unhandled
ISR vectors gets mapped to a single default handler function. Which is
hard to implement when LLVM tries to generate vectors on its own.

Reviewers: asl, krisb

Subscribers: hiraditya, JDevlieghere, awygle, llvm-commits

Tags: #llvm

Differential Revision: https://reviews.llvm.org/D67313

llvm-svn: 372910

# Summary
This cherry-pick fixes an llvm assertion failure that assumes LLVM will handle MSP430 interrupt vector section generation. While this is correct for MSP430 C code and TI's linker scripts, Rust opts to generate interrupt vectors in an incompatible way. If LLVM assertions are disabled, MSP430 code generation still somehow still works correctly [for the most part](https://github.com/YuhanLiin/msp430fr2355-quickstart/issues/3) (I don't understand why), but @pftbest and I agree it should be fixed properly anyway.