### PR TITLE
[lldb] Backport D72880: "Fix a buffer-size bug when the first DW_OP_piece is undefined"

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -2331,6 +2331,10 @@ bool DWARFExpression::Evaluate(
           // not available. Fill with zeros for now by resizing the data and
           // appending it
           curr_piece.ResizeData(piece_byte_size);
+          // Note that "0" is not a correct value for the unknown bits.
+          // It would be better to also return a mask of valid bits together
+          // with the expression result, so the debugger can print missing
+          // members as "<optimized out>" or something.
           ::memset(curr_piece.GetBuffer().GetBytes(), 0, piece_byte_size);
           pieces.AppendDataToHostBuffer(curr_piece);
         } else {
@@ -2445,8 +2449,8 @@ bool DWARFExpression::Evaluate(
               return false;
             }
           }
-          op_piece_offset += piece_byte_size;
         }
+        op_piece_offset += piece_byte_size;
       }
     } break;
 


### PR DESCRIPTION
See https://reviews.llvm.org/D72880 - althought the title says "first", this actually applies to any undef (i.e. optimized out or just padding bytes) `DW_OP_piece` that's not the very last one.

I hit this in https://github.com/rust-lang/rust/pull/48300#issuecomment-579027713, then [convinced myself that it's a `lldb` (not LLVM) bug](https://github.com/rust-lang/rust/pull/48300#issuecomment-579424438), then on IRC `labath` pointed me to the (recently landed!) [`D72880`](https://reviews.llvm.org/D72880), which solves it.

I only cherry-picked f55ab6f90b7317a6bb85303a6102702bdae1199e, and the unit test change didn't apply cleanly so I omitted it.

cc @nikomatsakis @alexcrichton @michaelwoerister