### PR TITLE
Fix link to "Updating LLVM" documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ first, and then we can cherry-pick them onto our branches if necessary.
 
 To learn more about updating LLVM in the Rust compiler, consult the
 [documentation for doing so in
-`rustc-guide`](https://rust-lang.github.io/rustc-guide/codegen/updating-llvm.html)
+`rustc-guide`](https://rustc-dev-guide.rust-lang.org/backend/updating-llvm.html)


### PR DESCRIPTION
The documentation was moved and is no longer accessible through the old link.