### PR TITLE
Fix sanitizer-common build with glibc 2.31

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
@@ -1127,10 +1127,11 @@ CHECK_SIZE_AND_OFFSET(ipc_perm, uid);
 CHECK_SIZE_AND_OFFSET(ipc_perm, gid);
 CHECK_SIZE_AND_OFFSET(ipc_perm, cuid);
 CHECK_SIZE_AND_OFFSET(ipc_perm, cgid);
-#if !defined(__aarch64__) || !SANITIZER_LINUX || __GLIBC_PREREQ (2, 21)
-/* On aarch64 glibc 2.20 and earlier provided incorrect mode field.  */
-CHECK_SIZE_AND_OFFSET(ipc_perm, mode);
-#endif
+// This patch is no longer necessary on LLVM 10.
+// #if !defined(__aarch64__) || !SANITIZER_LINUX || __GLIBC_PREREQ (2, 21)
+// /* On aarch64 glibc 2.20 and earlier provided incorrect mode field.  */
+// CHECK_SIZE_AND_OFFSET(ipc_perm, mode);
+// #endif
 
 CHECK_TYPE_SIZE(shmid_ds);
 CHECK_SIZE_AND_OFFSET(shmid_ds, shm_perm);


### PR DESCRIPTION
The type of ipc_perm mode field used by sanitizers is inconsistent with one
found in glibc 2.31, resulting in a test failure during build.

The sanitizers don't actually use the field directly and only care about the
size and alignment of the whole structure.

Disable the field check until the upgrade to LLVM 10 which addresses the issue
in more comprehensive way.