### PR TITLE
Inline assembly changes for RFC 2873

### DIFF
--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -1177,6 +1177,10 @@ static void rewriteInputConstraintReferences(unsigned FirstIn,
     if (NumDollars % 2 != 0 && Pos < AsmString.size()) {
       // We have an operand reference.
       size_t DigitStart = Pos;
+      if (AsmString[DigitStart] == '{') {
+        OS << '{';
+        ++DigitStart;
+      }
       size_t DigitEnd = AsmString.find_first_not_of("0123456789", DigitStart);
       if (DigitEnd == std::string::npos)
         DigitEnd = AsmString.size();

--- a/clang/test/CodeGen/mozilla-ms-inline-asm.c
+++ b/clang/test/CodeGen/mozilla-ms-inline-asm.c
@@ -27,7 +27,7 @@ void invoke(void* that, unsigned methodIndex,
 // CHECK-SAME: sub esp,eax
 // CHECK-SAME: mov ecx,esp
 // CHECK-SAME: push $0
-// CHECK-SAME: call dword ptr $2
+// CHECK-SAME: call dword ptr ${2:P}
 // CHECK-SAME: {{.*}}__MSASMLABEL_.${:uid}__noparams:
 // CHECK-SAME: mov ecx,$3
 // CHECK-SAME: push ecx

--- a/clang/test/CodeGen/ms-inline-asm.c
+++ b/clang/test/CodeGen/ms-inline-asm.c
@@ -306,7 +306,7 @@ void t24_helper(void) {}
 void t24() {
   __asm call t24_helper
 // CHECK: t24
-// CHECK: call void asm sideeffect inteldialect "call dword ptr $0", "*m,~{dirflag},~{fpsr},~{flags}"(void ()* @t24_helper)
+// CHECK: call void asm sideeffect inteldialect "call dword ptr ${0:P}", "*m,~{dirflag},~{fpsr},~{flags}"(void ()* @t24_helper)
 }
 
 void t25() {
@@ -681,7 +681,7 @@ void dot_operator(){
 void call_clobber() {
   __asm call t41
   // CHECK-LABEL: define void @call_clobber
-  // CHECK: call void asm sideeffect inteldialect "call dword ptr $0", "*m,~{dirflag},~{fpsr},~{flags}"(void (i16)* @t41)
+  // CHECK: call void asm sideeffect inteldialect "call dword ptr ${0:P}", "*m,~{dirflag},~{fpsr},~{flags}"(void (i16)* @t41)
 }
 
 void xgetbv() {

--- a/clang/test/CodeGen/ms-inline-asm.cpp
+++ b/clang/test/CodeGen/ms-inline-asm.cpp
@@ -109,7 +109,7 @@ void test5() {
   __asm mov x, eax
   // CHECK: call void asm sideeffect inteldialect
   // CHECK-SAME: push $0
-  // CHECK-SAME: call dword ptr $2
+  // CHECK-SAME: call dword ptr ${2:P}
   // CHECK-SAME: mov $1, eax
   // CHECK-SAME: "=*m,=*m,*m,~{esp},~{dirflag},~{fpsr},~{flags}"(i32* %y, i32* %x, i32 (float)* @_ZN2T5IiE6createIfEEiT_)
 }

--- a/llvm/include/llvm/MC/MCParser/MCParsedAsmOperand.h
+++ b/llvm/include/llvm/MC/MCParser/MCParsedAsmOperand.h
@@ -71,6 +71,10 @@ public:
   /// variable/label?   Only valid when parsing MS-style inline assembly.
   virtual bool needAddressOf() const { return false; }
 
+  /// isCallOperand - Is this an operand of an inline-assembly call instruction?
+  /// Only valid when parsing MS-style inline assembly.
+  virtual bool isCallOperand() const { return false; }
+
   /// isOffsetOf - Do we need to emit code to get the offset of the variable,
   /// rather then the value of the variable?   Only valid when parsing MS-style
   /// inline assembly.

--- a/llvm/include/llvm/MC/MCParser/MCTargetAsmParser.h
+++ b/llvm/include/llvm/MC/MCParser/MCTargetAsmParser.h
@@ -35,6 +35,7 @@ enum AsmRewriteKind {
   AOK_Align,          // Rewrite align as .align.
   AOK_EVEN,           // Rewrite even as .even.
   AOK_Emit,           // Rewrite _emit as .byte.
+  AOK_CallInput,      // Rewrite in terms of ${N:P}.
   AOK_Input,          // Rewrite in terms of $N.
   AOK_Output,         // Rewrite in terms of $N.
   AOK_SizeDirective,  // Add a sizing directive (e.g., dword ptr).
@@ -49,6 +50,7 @@ const char AsmRewritePrecedence [] = {
   2, // AOK_EVEN
   2, // AOK_Emit
   3, // AOK_Input
+  3, // AOK_CallInput
   3, // AOK_Output
   5, // AOK_SizeDirective
   1, // AOK_Label

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -5728,7 +5728,10 @@ bool AsmParser::parseMSInlineAsm(
         InputDecls.push_back(OpDecl);
         InputDeclsAddressOf.push_back(Operand.needAddressOf());
         InputConstraints.push_back(Operand.getConstraint().str());
-        AsmStrRewrites.emplace_back(AOK_Input, Start, SymName.size());
+        if (Operand.isCallOperand())
+          AsmStrRewrites.emplace_back(AOK_CallInput, Start, SymName.size());
+        else
+          AsmStrRewrites.emplace_back(AOK_Input, Start, SymName.size());
       }
     }
 
@@ -5817,6 +5820,9 @@ bool AsmParser::parseMSInlineAsm(
       break;
     case AOK_Input:
       OS << '$' << InputIdx++;
+      break;
+    case AOK_CallInput:
+      OS << "${" << InputIdx++ << ":P}";
       break;
     case AOK_Output:
       OS << '$' << OutputIdx++;

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -2855,6 +2855,15 @@ bool X86AsmParser::ParseInstruction(ParseInstructionInfo &Info, StringRef Name,
     }
   }
 
+  // Mark the operands of a call instruction.  These need to be handled
+  // differently when referenced in MS-style inline assembly.
+  if (Name.startswith("call") || Name.startswith("lcall")) {
+    for (size_t i = 1; i < Operands.size(); ++i) {
+      X86Operand &Op = static_cast<X86Operand &>(*Operands[i]);
+      Op.setCallOperand(true);
+    }
+  }
+
   if (Flags)
     Operands.push_back(X86Operand::CreatePrefix(Flags, NameLoc, NameLoc));
   return false;

--- a/llvm/lib/Target/X86/AsmParser/X86Operand.h
+++ b/llvm/lib/Target/X86/AsmParser/X86Operand.h
@@ -36,6 +36,7 @@ struct X86Operand final : public MCParsedAsmOperand {
   StringRef SymName;
   void *OpDecl;
   bool AddressOf;
+  bool CallOperand;
 
   struct TokOp {
     const char *Data;
@@ -77,7 +78,7 @@ struct X86Operand final : public MCParsedAsmOperand {
   };
 
   X86Operand(KindTy K, SMLoc Start, SMLoc End)
-      : Kind(K), StartLoc(Start), EndLoc(End) {}
+      : Kind(K), StartLoc(Start), EndLoc(End), CallOperand(false) {}
 
   StringRef getSymName() override { return SymName; }
   void *getOpDecl() override { return OpDecl; }
@@ -276,6 +277,9 @@ struct X86Operand final : public MCParsedAsmOperand {
   bool needAddressOf() const override {
     return AddressOf;
   }
+
+  bool isCallOperand() const override { return CallOperand; }
+  void setCallOperand(bool IsCallOperand) { CallOperand = IsCallOperand; }
 
   bool isMem() const override { return Kind == Memory; }
   bool isMemUnsized() const {

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -336,13 +336,21 @@ void X86AsmPrinter::PrintMemReference(const MachineInstr *MI, unsigned OpNo,
   PrintLeaMemReference(MI, OpNo, O, Modifier);
 }
 
+
 void X86AsmPrinter::PrintIntelMemReference(const MachineInstr *MI,
-                                           unsigned OpNo, raw_ostream &O) {
+                                           unsigned OpNo, raw_ostream &O,
+                                           const char *Modifier) {
   const MachineOperand &BaseReg = MI->getOperand(OpNo + X86::AddrBaseReg);
   unsigned ScaleVal = MI->getOperand(OpNo + X86::AddrScaleAmt).getImm();
   const MachineOperand &IndexReg = MI->getOperand(OpNo + X86::AddrIndexReg);
   const MachineOperand &DispSpec = MI->getOperand(OpNo + X86::AddrDisp);
   const MachineOperand &SegReg = MI->getOperand(OpNo + X86::AddrSegmentReg);
+
+  // If we really don't want to print out (rip), don't.
+  bool HasBaseReg = BaseReg.getReg() != 0;
+  if (HasBaseReg && Modifier && !strcmp(Modifier, "no-rip") &&
+      BaseReg.getReg() == X86::RIP)
+    HasBaseReg = false;
 
   // If this has a segment register, print it.
   if (SegReg.getReg()) {
@@ -353,7 +361,7 @@ void X86AsmPrinter::PrintIntelMemReference(const MachineInstr *MI,
   O << '[';
 
   bool NeedPlus = false;
-  if (BaseReg.getReg()) {
+  if (HasBaseReg) {
     PrintOperand(MI, OpNo + X86::AddrBaseReg, O);
     NeedPlus = true;
   }
@@ -371,7 +379,7 @@ void X86AsmPrinter::PrintIntelMemReference(const MachineInstr *MI,
     PrintOperand(MI, OpNo + X86::AddrDisp, O);
   } else {
     int64_t DispVal = DispSpec.getImm();
-    if (DispVal || (!IndexReg.getReg() && !BaseReg.getReg())) {
+    if (DispVal || (!IndexReg.getReg() && !HasBaseReg)) {
       if (NeedPlus) {
         if (DispVal > 0)
           O << " + ";
@@ -524,11 +532,6 @@ bool X86AsmPrinter::PrintAsmOperand(const MachineInstr *MI, unsigned OpNo,
 bool X86AsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI, unsigned OpNo,
                                           const char *ExtraCode,
                                           raw_ostream &O) {
-  if (MI->getInlineAsmDialect() == InlineAsm::AD_Intel) {
-    PrintIntelMemReference(MI, OpNo, O);
-    return false;
-  }
-
   if (ExtraCode && ExtraCode[0]) {
     if (ExtraCode[1] != 0) return true; // Unknown modifier.
 
@@ -542,14 +545,26 @@ bool X86AsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI, unsigned OpNo,
       // These only apply to registers, ignore on mem.
       break;
     case 'H':
-      PrintMemReference(MI, OpNo, O, "H");
+      if (MI->getInlineAsmDialect() == InlineAsm::AD_Intel) {
+        return true;  // Unsupported modifier in Intel inline assembly.
+      } else {
+        PrintMemReference(MI, OpNo, O, "H");
+      }
       return false;
     case 'P': // Don't print @PLT, but do print as memory.
-      PrintMemReference(MI, OpNo, O, "no-rip");
+      if (MI->getInlineAsmDialect() == InlineAsm::AD_Intel) {
+        PrintIntelMemReference(MI, OpNo, O, "no-rip");
+      } else {
+        PrintMemReference(MI, OpNo, O, "no-rip");
+      }
       return false;
     }
   }
-  PrintMemReference(MI, OpNo, O, nullptr);
+  if (MI->getInlineAsmDialect() == InlineAsm::AD_Intel) {
+    PrintIntelMemReference(MI, OpNo, O, nullptr);
+  } else {
+    PrintMemReference(MI, OpNo, O, nullptr);
+  }
   return false;
 }
 

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -397,7 +397,7 @@ void X86AsmPrinter::PrintIntelMemReference(const MachineInstr *MI,
 static bool printAsmMRegister(X86AsmPrinter &P, const MachineOperand &MO,
                               char Mode, raw_ostream &O) {
   unsigned Reg = MO.getReg();
-  bool EmitPercent = true;
+  bool EmitPercent = MO.getParent()->getInlineAsmDialect() == InlineAsm::AD_ATT;
 
   if (!X86::GR8RegClass.contains(Reg) &&
       !X86::GR16RegClass.contains(Reg) &&
@@ -426,6 +426,42 @@ static bool printAsmMRegister(X86AsmPrinter &P, const MachineOperand &MO,
     // Print 64-bit register names if 64-bit integer registers are available.
     // Otherwise, print 32-bit register names.
     Reg = getX86SubSuperRegister(Reg, P.getSubtarget().is64Bit() ? 64 : 32);
+    break;
+  }
+
+  if (EmitPercent)
+    O << '%';
+
+  O << X86ATTInstPrinter::getRegisterName(Reg);
+  return false;
+}
+
+static bool printAsmVRegister(X86AsmPrinter &P, const MachineOperand &MO,
+                              char Mode, raw_ostream &O) {
+  unsigned Reg = MO.getReg();
+  bool EmitPercent = MO.getParent()->getInlineAsmDialect() == InlineAsm::AD_ATT;
+
+  unsigned Index;
+  if (X86::VR128XRegClass.contains(Reg))
+    Index = Reg - X86::XMM0;
+  else if (X86::VR256XRegClass.contains(Reg))
+    Index = Reg - X86::YMM0;
+  else if (X86::VR512RegClass.contains(Reg))
+    Index = Reg - X86::ZMM0;
+  else
+    return true;
+
+  switch (Mode) {
+  default: // Unknown mode.
+    return true;
+  case 'x': // Print V4SFmode register
+    Reg = X86::XMM0 + Index;
+    break;
+  case 't': // Print V8SFmode register
+    Reg = X86::YMM0 + Index;
+    break;
+  case 'g': // Print V16SFmode register
+    Reg = X86::ZMM0 + Index;
     break;
   }
 
@@ -507,6 +543,14 @@ bool X86AsmPrinter::PrintAsmOperand(const MachineInstr *MI, unsigned OpNo,
     case 'V': // Print native register without '%'
       if (MO.isReg())
         return printAsmMRegister(*this, MO, ExtraCode[0], O);
+      PrintOperand(MI, OpNo, O);
+      return false;
+
+    case 'x': // Print V4SFmode register
+    case 't': // Print V8SFmode register
+    case 'g': // Print V16SFmode register
+      if (MO.isReg())
+        return printAsmVRegister(*this, MO, ExtraCode[0], O);
       PrintOperand(MI, OpNo, O);
       return false;
 

--- a/llvm/lib/Target/X86/X86AsmPrinter.h
+++ b/llvm/lib/Target/X86/X86AsmPrinter.h
@@ -112,7 +112,7 @@ class LLVM_LIBRARY_VISIBILITY X86AsmPrinter : public AsmPrinter {
   void PrintMemReference(const MachineInstr *MI, unsigned OpNo, raw_ostream &O,
                          const char *Modifier);
   void PrintIntelMemReference(const MachineInstr *MI, unsigned OpNo,
-                              raw_ostream &O);
+                              raw_ostream &O, const char *Modifier);
 
 public:
   X86AsmPrinter(TargetMachine &TM, std::unique_ptr<MCStreamer> Streamer);

--- a/llvm/test/CodeGen/X86/asm-modifier2.ll
+++ b/llvm/test/CodeGen/X86/asm-modifier2.ll
@@ -1,0 +1,53 @@
+; RUN: llc < %s | FileCheck %s
+
+define void @test1() {
+; CHECK-LABEL: test1:
+; CHECK: vmovaps %xmm0, %xmm0
+; CHECK: vmovaps %ymm0, %ymm0
+; CHECK: vmovaps %zmm0, %zmm0
+  tail call void asm sideeffect "vmovaps ${0:x}, ${0:x}", "{xmm0},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  tail call void asm sideeffect "vmovaps ${0:t}, ${0:t}", "{xmm0},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  tail call void asm sideeffect "vmovaps ${0:g}, ${0:g}", "{xmm0},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  ret void
+}
+
+define void @test2() {
+; CHECK-LABEL: test2:
+; CHECK: vmovaps %xmm0, %xmm0
+; CHECK: vmovaps %ymm0, %ymm0
+; CHECK: vmovaps %zmm0, %zmm0
+  tail call void asm sideeffect inteldialect "vmovaps ${0:x}, ${0:x}", "{xmm0},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  tail call void asm sideeffect inteldialect "vmovaps ${0:t}, ${0:t}", "{xmm0},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  tail call void asm sideeffect inteldialect "vmovaps ${0:g}, ${0:g}", "{xmm0},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  ret void
+}
+
+define void @test3() {
+; CHECK-LABEL: test3:
+; CHECK: movb %al, %al
+; CHECK: movb %ah, %ah
+; CHECK: movw %ax, %ax
+; CHECK: movl %eax, %eax
+; CHECK: movq %rax, %rax
+  tail call void asm sideeffect "mov ${0:b}, ${0:b}", "{eax},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  tail call void asm sideeffect "mov ${0:h}, ${0:h}", "{eax},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  tail call void asm sideeffect "mov ${0:w}, ${0:w}", "{eax},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  tail call void asm sideeffect "mov ${0:k}, ${0:k}", "{eax},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  tail call void asm sideeffect "mov ${0:q}, ${0:q}", "{eax},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  ret void
+}
+
+define void @test4() {
+; CHECK-LABEL: test4:
+; CHECK: movb %al, %al
+; CHECK: movb %ah, %ah
+; CHECK: movw %ax, %ax
+; CHECK: movl %eax, %eax
+; CHECK: movq %rax, %rax
+  tail call void asm sideeffect inteldialect "mov ${0:b}, ${0:b}", "{eax},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  tail call void asm sideeffect inteldialect "mov ${0:h}, ${0:h}", "{eax},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  tail call void asm sideeffect inteldialect "mov ${0:w}, ${0:w}", "{eax},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  tail call void asm sideeffect inteldialect "mov ${0:k}, ${0:k}", "{eax},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  tail call void asm sideeffect inteldialect "mov ${0:q}, ${0:q}", "{eax},~{dirflag},~{fpsr},~{flags}"(i32 0)
+  ret void
+}

--- a/llvm/test/CodeGen/X86/inline-asm-bad-modifier.ll
+++ b/llvm/test/CodeGen/X86/inline-asm-bad-modifier.ll
@@ -1,8 +1,8 @@
 ; RUN: not llc -mtriple=x86_64-- < %s 2>&1 | FileCheck %s
 
-;CHECK: error: invalid operand in inline asm: 'vmovd ${1:x}, $0'
+;CHECK: error: invalid operand in inline asm: 'vmovd ${1:k}, $0'
 define i32 @foo() {
 entry:
-  %0 = tail call i32 asm sideeffect "vmovd ${1:x}, $0", "=r,x,~{dirflag},~{fpsr},~{flags}"(<2 x i64> <i64 240518168632, i64 240518168632>)
+  %0 = tail call i32 asm sideeffect "vmovd ${1:k}, $0", "=r,x,~{dirflag},~{fpsr},~{flags}"(<2 x i64> <i64 240518168632, i64 240518168632>)
   ret i32 %0
 }

--- a/llvm/test/CodeGen/X86/ms-inline-asm-PR44272.ll
+++ b/llvm/test/CodeGen/X86/ms-inline-asm-PR44272.ll
@@ -1,0 +1,18 @@
+; RUN: llc < %s -mtriple=i686-- | FileCheck %s
+; RUN: llc < %s -mtriple=x86_64-- | FileCheck %s
+
+define void @func() {
+entry:
+  ret void
+}
+
+define void @main() {
+entry:
+  call void asm sideeffect inteldialect "call ${0:P}", "*m,~{dirflag},~{fpsr},~{flags}"(void ()* @func)
+  ret void
+; CHECK-LABEL: main:
+; CHECK: {{## InlineAsm Start|#APP}}
+; CHECK: {{call(l|q) func$}}
+; CHECK: {{## InlineAsm End|#NO_APP}}
+; CHECK: ret{{l|q}}
+}


### PR DESCRIPTION
This backports 2 commits which are necessary for the new inline assembly support ([RFC](https://github.com/rust-lang/rfcs/pull/2873), [PR](https://github.com/rust-lang/rust/pull/69171)).

Differentials:
- https://reviews.llvm.org/D71677
- https://reviews.llvm.org/D78977