### PR TITLE
ValueMapper does not preserve inline assembly dialect when remapping the type

### DIFF
--- a/llvm/lib/Transforms/Utils/ValueMapper.cpp
+++ b/llvm/lib/Transforms/Utils/ValueMapper.cpp
@@ -369,7 +369,8 @@ Value *Mapper::mapValue(const Value *V) {
 
       if (NewTy != IA->getFunctionType())
         V = InlineAsm::get(NewTy, IA->getAsmString(), IA->getConstraintString(),
-                           IA->hasSideEffects(), IA->isAlignStack());
+                           IA->hasSideEffects(), IA->isAlignStack(),
+                           IA->getDialect());
     }
 
     return getVM()[V] = const_cast<Value *>(V);


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/70337

Differential Revision: https://reviews.llvm.org/D80066