### PR TITLE
lld NOLOAD fix

### DIFF
--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -737,6 +737,7 @@ bool ScriptParser::readSectionDirective(OutputSection *cmd, StringRef tok1, Stri
   expect("(");
   if (consume("NOLOAD")) {
     cmd->noload = true;
+    cmd->type = SHT_NOBITS;
   } else {
     skip(); // This is "COPY", "INFO" or "OVERLAY".
     cmd->nonAlloc = true;


### PR DESCRIPTION
I'm hoping this is the right avenue to backport fixes like this...

Rust nightly 2020-05-22 and later ships lld with a regression related to linker scripts: `NOLOAD` sections incorrectly generate sections filled with `0`s. This causes gdb and other elf loaders to write to reserved or otherwise invalid addresses (gdb also seems confused by the resulting ELF files and spits out a warning about the sections). This is particularly a problem for embedded rust projects that use lld by default and have affected linker scripts (cortex-m-rt based projects for instance).

---

[lld][ELF] Mark empty NOLOAD output sections SHT_NOBITS instead of SHT_PROGBITS

This fixes PR# 45336.
Output sections described in a linker script as NOLOAD with no input sections would be marked as SHT_PROGBITS.

Reviewed By: MaskRay

Differential Revision: https://reviews.llvm.org/D76981