### PR TITLE
Fix FastISel dropping srcloc metadata from InlineAsm

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
@@ -1322,12 +1322,19 @@ bool FastISel::selectCall(const User *I) {
       ExtraInfo |= InlineAsm::Extra_HasSideEffects;
     if (IA->isAlignStack())
       ExtraInfo |= InlineAsm::Extra_IsAlignStack;
+    if (Call->isConvergent())
+      ExtraInfo |= InlineAsm::Extra_IsConvergent;
     ExtraInfo |= IA->getDialect() * InlineAsm::Extra_AsmDialect;
 
-    BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, DbgLoc,
-            TII.get(TargetOpcode::INLINEASM))
-        .addExternalSymbol(IA->getAsmString().c_str())
-        .addImm(ExtraInfo);
+    MachineInstrBuilder MIB = BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, DbgLoc,
+                                      TII.get(TargetOpcode::INLINEASM));
+    MIB.addExternalSymbol(IA->getAsmString().c_str());
+    MIB.addImm(ExtraInfo);
+
+    const MDNode *SrcLoc = Call->getMetadata("srcloc");
+    if (SrcLoc)
+      MIB.addMetadata(SrcLoc);
+
     return true;
   }
 

--- a/llvm/test/CodeGen/AArch64/asm-srcloc.ll
+++ b/llvm/test/CodeGen/AArch64/asm-srcloc.ll
@@ -1,0 +1,21 @@
+; RUN: llc -O0 -stop-after=finalize-isel -o - %s | FileCheck %s
+
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64"
+
+; CHECK-LABEL: name: foo
+; CHECK: INLINEASM {{.*}}, !0
+define void @foo() {
+  call void asm sideeffect "nowayisthisavalidinstruction", "r"(i32 0), !srcloc !0
+  ret void
+}
+
+; CHECK-LABEL: name: bar
+; CHECK: INLINEASM {{.*}}, !1
+define void @bar() {
+  call void asm sideeffect "nowayisthisavalidinstruction", ""(), !srcloc !1
+  ret void
+}
+
+!0 = !{i32 23}
+!1 = !{i32 91}


### PR DESCRIPTION
Summary:
Bugzilla: https://bugs.llvm.org/show_bug.cgi?id=46060

I've also added the Extra_IsConvergent flag which was missing from FastISel.

Reviewers: echristo

Reviewed By: echristo

Subscribers: hiraditya, llvm-commits

Tags: #llvm

Differential Revision: https://reviews.llvm.org/D80759