### PR TITLE
Add option LLVM_NM to allow specifying the location of the llvm-nm tool

### DIFF
--- a/llvm/tools/llvm-shlib/CMakeLists.txt
+++ b/llvm/tools/llvm-shlib/CMakeLists.txt
@@ -154,13 +154,17 @@ if(MSVC)
   set(GEN_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/gen-msvc-exports.py)
 
   set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/libllvm-c.exports)
-
-  if(CMAKE_CROSSCOMPILING)
-    build_native_tool(llvm-nm llvm_nm)
-    set(llvm_nm_target "${llvm_nm}")
+  if(NOT LLVM_NM)
+    if(CMAKE_CROSSCOMPILING)
+      build_native_tool(llvm-nm llvm_nm)
+      set(llvm_nm_target "${llvm_nm}")
+    else()
+      set(llvm_nm $<TARGET_FILE:llvm-nm>)
+      set(llvm_nm_target llvm-nm)
+    endif()
   else()
-    set(llvm_nm $<TARGET_FILE:llvm-nm>)
-    set(llvm_nm_target llvm-nm)
+    set(llvm_nm ${LLVM_NM})
+    set(llvm_nm_target "")
   endif()
 
   add_custom_command(OUTPUT ${LLVM_EXPORTED_SYMBOL_FILE}


### PR DESCRIPTION
Fixes an issue related to cross-compiling rustc for aarch64-pc-windows-msvc. Cherry-picked from LLVM master.

When cross-building LLVM, cmake attempts to build the native `llvm-nm` tool by recursing `cmake`. However, since we pass the compiler path and flags as cmake options, cmake still compiles `llvm-nm` for the target architecture, rather than the host. When targeting aarch64, this results in a binary that cannot run on the build machine.

See rust-lang/rust#72881 for more details. The next step is to use the new `LLVM_NM` option from the rustc build.