### PR TITLE
[X86] Fix to X86LoadValueInjectionRetHardeningPass for possible segfault

### DIFF
--- a/llvm/lib/Target/X86/X86LoadValueInjectionRetHardening.cpp
+++ b/llvm/lib/Target/X86/X86LoadValueInjectionRetHardening.cpp
@@ -99,6 +99,9 @@ bool X86LoadValueInjectionRetHardeningPass::runOnMachineFunction(
 
   bool Modified = false;
   for (auto &MBB : MF) {
+    if (MBB.empty())
+      continue;
+
     MachineInstr &MI = MBB.back();
     if (MI.getOpcode() != X86::RETQ)
       continue;


### PR DESCRIPTION
`MBB.back()` could segfault if `MBB.empty()`. Fixed by checking for `MBB.empty()` in the loop.

Differential Revision: https://reviews.llvm.org/D77584

(cherry picked from commit 0505181006f1088b2cb28a7240d5f27613783307)

Additional details:
- Crash does happen - issue reported at: https://github.com/fortanix/rust-sgx/issues/267 (segfault and all info available there)