### PR TITLE
[AArch64][GlobalISel] Handle rtcGPR64RegClassID in AArch64RegisterBankInfo::getRegBankFromRegClass()

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
@@ -261,6 +261,7 @@ AArch64RegisterBankInfo::getRegBankFromRegClass(const TargetRegisterClass &RC,
   case AArch64::GPR64common_and_GPR64noipRegClassID:
   case AArch64::GPR64noip_and_tcGPR64RegClassID:
   case AArch64::tcGPR64RegClassID:
+  case AArch64::rtcGPR64RegClassID:
   case AArch64::WSeqPairsClassRegClassID:
   case AArch64::XSeqPairsClassRegClassID:
     return getRegBank(AArch64::GPRRegBankID);

--- a/llvm/test/CodeGen/AArch64/GlobalISel/regbankselect-default.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/regbankselect-default.mir
@@ -75,6 +75,8 @@
 
   define void @test_gphi_ptr() { ret void }
 
+  define void @test_restricted_tail_call() { ret void }
+
 ...
 
 ---
@@ -887,4 +889,21 @@ body:             |
     $x0 = COPY %3(p0)
     RET_ReallyLR implicit $x0
 
+...
+
+---
+name:            test_restricted_tail_call
+legalized:       true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $x16, $x17
+    ; CHECK-LABEL: name: test_restricted_tail_call
+    ; CHECK: liveins: $x16, $x17
+    ; CHECK: [[COPY:%[0-9]+]]:gpr(s64) = COPY $x16
+    ; CHECK: [[COPY1:%[0-9]+]]:gpr(s64) = COPY $x17
+    ; CHECK: RET_ReallyLR
+    %0:_(s64) = COPY $x16
+    %1:_(s64) = COPY $x17
+    RET_ReallyLR
 ...


### PR DESCRIPTION
TargetRegisterInfo::getMinimalPhysRegClass() returns rtcGPR64RegClassID for X16
and X17, as it's the last matching class. This in turn gets passed to
AArch64RegisterBankInfo::getRegBankFromRegClass(), which hits an unreachable.

It seems sensible to handle this case, so copies from X16 and X17 work.
Copying from X17 is used in inline assembly in libunwind for pointer
authentication.

Differential Revision: https://reviews.llvm.org/D85720