### PR TITLE
Update __rust_{alloc,realloc} builtins

### DIFF
--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -1491,10 +1491,9 @@ bool TargetLibraryInfoImpl::isValidProtoForLibFunc(const FunctionType &FTy,
   }
 
   case LibFunc_rust_alloc:
-    return (NumParams == 3 && FTy.getReturnType()->isPointerTy() &&
+    return (NumParams == 2 && FTy.getReturnType()->isPointerTy() &&
             FTy.getParamType(0)->isIntegerTy() &&
-            FTy.getParamType(1)->isIntegerTy() &&
-            FTy.getParamType(2)->isPointerTy());
+            FTy.getParamType(1)->isIntegerTy());
 
   case LibFunc_rust_dealloc:
     return (NumParams == 3 && FTy.getReturnType()->isVoidTy() &&
@@ -1503,13 +1502,11 @@ bool TargetLibraryInfoImpl::isValidProtoForLibFunc(const FunctionType &FTy,
             FTy.getParamType(2)->isIntegerTy());
 
   case LibFunc_rust_realloc:
-    return (NumParams == 6 && FTy.getReturnType()->isPointerTy() &&
+    return (NumParams == 4 && FTy.getReturnType()->isPointerTy() &&
             FTy.getParamType(0)->isPointerTy() &&
             FTy.getParamType(1)->isIntegerTy() &&
             FTy.getParamType(2)->isIntegerTy() &&
-            FTy.getParamType(3)->isIntegerTy() &&
-            FTy.getParamType(4)->isIntegerTy() &&
-            FTy.getParamType(5)->isPointerTy());
+            FTy.getParamType(3)->isIntegerTy());
 
   case LibFunc::NumLibFuncs:
   case LibFunc::NotLibFunc:

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -1491,22 +1491,9 @@ bool TargetLibraryInfoImpl::isValidProtoForLibFunc(const FunctionType &FTy,
   }
 
   case LibFunc_rust_alloc:
-    return (NumParams == 2 && FTy.getReturnType()->isPointerTy() &&
-            FTy.getParamType(0)->isIntegerTy() &&
-            FTy.getParamType(1)->isIntegerTy());
-
   case LibFunc_rust_dealloc:
-    return (NumParams == 3 && FTy.getReturnType()->isVoidTy() &&
-            FTy.getParamType(0)->isPointerTy() &&
-            FTy.getParamType(1)->isIntegerTy() &&
-            FTy.getParamType(2)->isIntegerTy());
-
   case LibFunc_rust_realloc:
-    return (NumParams == 4 && FTy.getReturnType()->isPointerTy() &&
-            FTy.getParamType(0)->isPointerTy() &&
-            FTy.getParamType(1)->isIntegerTy() &&
-            FTy.getParamType(2)->isIntegerTy() &&
-            FTy.getParamType(3)->isIntegerTy());
+    return true;
 
   case LibFunc::NumLibFuncs:
   case LibFunc::NotLibFunc:


### PR DESCRIPTION
The prototypes for these alloc functions changed in library/alloc and need updating here.

Uncovered as part of zulip discussion [here](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/llvm.20fork.20prototypes.20rust_alloc.20with.203.20params).