### PR TITLE
Revert "[Support] PR42623: Avoid setting the delete-on-close bit if a…

### DIFF
--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -402,20 +402,6 @@ std::error_code is_local(int FD, bool &Result) {
 }
 
 static std::error_code setDeleteDisposition(HANDLE Handle, bool Delete) {
-  // First, check if the file is on a network (non-local) drive. If so, don't
-  // set DeleteFile to true, since it prevents opening the file for writes.
-  SmallVector<wchar_t, 128> FinalPath;
-  if (std::error_code EC = realPathFromHandle(Handle, FinalPath))
-    return EC;
-
-  bool IsLocal;
-  if (std::error_code EC = is_local_internal(FinalPath, IsLocal))
-    return EC;
-
-  if (!IsLocal)
-    return std::error_code();
-
-  // The file is on a local drive, set the DeleteFile to true.
   FILE_DISPOSITION_INFO Disposition;
   Disposition.DeleteFile = Delete;
   if (!SetFileInformationByHandle(Handle, FileDispositionInfo, &Disposition,


### PR DESCRIPTION
… TempFile doesn't reside on a local drive"

This reverts commit 79657e2339b58bc01fe1b85a448bb073d57d90bb.

The change regressed on Windows 7 -- rust-lang/rust#81051