### PR TITLE
[WebAssembly] Fix i8x16.popcnt opcode

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
@@ -831,7 +831,7 @@ defm ANYTRUE : SIMDReduce<int_wasm_anytrue, "any_true", 98>;
 defm ALLTRUE : SIMDReduce<int_wasm_alltrue, "all_true", 99>;
 
 // Population count: popcnt
-defm POPCNT : SIMDUnary<I8x16, int_wasm_popcnt, "popcnt", 124>;
+defm POPCNT : SIMDUnary<I8x16, int_wasm_popcnt, "popcnt", 0x62>;
 
 // Reductions already return 0 or 1, so and 1, setne 0, and seteq 1
 // can be folded out

--- a/llvm/test/MC/WebAssembly/simd-encodings.s
+++ b/llvm/test/MC/WebAssembly/simd-encodings.s
@@ -324,7 +324,8 @@ main:
     # CHECK: i8x16.neg # encoding: [0xfd,0x61]
     i8x16.neg
 
-    # TODO: i8x16.popcnt # encoding: [0xfd,0x62]
+    # CHECK: i8x16.popcnt # encoding: [0xfd,0x62]
+    i8x16.popcnt
 
     # CHECK: i8x16.all_true # encoding: [0xfd,0x63]
     i8x16.all_true


### PR DESCRIPTION
When I updated the SIMD opcodes in f5764a8654e3, I accidentally missed updating
i8x16.popcnt. This patch fixes the omission.

Differential Revision: https://reviews.llvm.org/D99536