### PR TITLE
[ConstantMerge] Don't merge thread_local constants with non-thread_local constants

### DIFF
--- a/llvm/lib/Transforms/IPO/ConstantMerge.cpp
+++ b/llvm/lib/Transforms/IPO/ConstantMerge.cpp
@@ -95,6 +95,8 @@ isUnmergeableGlobal(GlobalVariable *GV,
   // Only process constants with initializers in the default address space.
   return !GV->isConstant() || !GV->hasDefinitiveInitializer() ||
          GV->getType()->getAddressSpace() != 0 || GV->hasSection() ||
+         // Don't touch thread-local variables.
+         GV->isThreadLocal() ||
          // Don't touch values marked with attribute(used).
          UsedGlobals.count(GV);
 }

--- a/llvm/test/Transforms/ConstantMerge/dont-merge.ll
+++ b/llvm/test/Transforms/ConstantMerge/dont-merge.ll
@@ -80,3 +80,15 @@ define void @test4(i32** %P1, i32** %P2, i32** %P3, i32** %P4, i32** %P5, i32** 
         store i32* @T4D2, i32** %P8
         ret void
 }
+
+; CHECK: @T5tls
+; CHECK: @T5ua
+
+@T5tls = private thread_local constant i32 555
+@T5ua = private unnamed_addr constant i32 555
+
+define void @test5(i32** %P1, i32** %P2) {
+        store i32* @T5tls, i32** %P1
+        store i32* @T5ua, i32** %P2
+        ret void
+}


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/issues/84025