### PR TITLE
Backport BPF inline asm support for 32 bit registers

### DIFF
--- a/clang/lib/Basic/Targets/BPF.cpp
+++ b/clang/lib/Basic/Targets/BPF.cpp
@@ -46,3 +46,14 @@ ArrayRef<Builtin::Info> BPFTargetInfo::getTargetBuiltins() const {
   return llvm::makeArrayRef(BuiltinInfo, clang::BPF::LastTSBuiltin -
                                              Builtin::FirstTSBuiltin);
 }
+
+bool BPFTargetInfo::handleTargetFeatures(std::vector<std::string> &Features,
+                                         DiagnosticsEngine &Diags) {
+  for (const auto &Feature : Features) {
+    if (Feature == "+alu32") {
+      HasAlu32 = true;
+    }
+  }
+
+  return true;
+}

--- a/clang/test/CodeGen/bpf-inline-asm.c
+++ b/clang/test/CodeGen/bpf-inline-asm.c
@@ -1,0 +1,31 @@
+// REQUIRES: bpf-registered-target
+// RUN: %clang -target bpf -emit-llvm -S -Xclang -target-feature -Xclang +alu32 %s -o - | FileCheck %s
+// RUN: %clang -target bpf -emit-llvm -S -mcpu=v3 %s -o - | FileCheck %s
+
+void test_generic_constraints(int var32, long var64) {
+  asm("%0 = %1"
+      : "=r"(var32)
+      : "0"(var32));
+  // CHECK: [[R32_ARG:%[a-zA-Z0-9]+]] = load i32, i32*
+  // CHECK: call i32 asm "$0 = $1", "=r,0"(i32 [[R32_ARG]])
+
+  asm("%0 = %1"
+      : "=r"(var64)
+      : "0"(var64));
+  // CHECK: [[R64_ARG:%[a-zA-Z0-9]+]] = load i64, i64*
+  // CHECK: call i64 asm "$0 = $1", "=r,0"(i64 [[R64_ARG]])
+
+  asm("%0 = %1"
+      : "=r"(var64)
+      : "r"(var64));
+  // CHECK: [[R64_ARG:%[a-zA-Z0-9]+]] = load i64, i64*
+  // CHECK: call i64 asm "$0 = $1", "=r,r"(i64 [[R64_ARG]])
+}
+
+void test_constraint_w(int a) {
+  asm("%0 = %1"
+      : "=w"(a)
+      : "w"(a));
+  // CHECK: [[R32_ARG:%[a-zA-Z0-9]+]] = load i32, i32*
+  // CHECK: call i32 asm "$0 = $1", "=w,w"(i32 [[R32_ARG]])
+}

--- a/llvm/lib/Target/BPF/BPFISelLowering.cpp
+++ b/llvm/lib/Target/BPF/BPFISelLowering.cpp
@@ -202,6 +202,20 @@ bool BPFTargetLowering::isZExtFree(EVT VT1, EVT VT2) const {
   return NumBits1 == 32 && NumBits2 == 64;
 }
 
+BPFTargetLowering::ConstraintType
+BPFTargetLowering::getConstraintType(StringRef Constraint) const {
+  if (Constraint.size() == 1) {
+    switch (Constraint[0]) {
+    default:
+      break;
+    case 'w':
+      return C_RegisterClass;
+    }
+  }
+
+  return TargetLowering::getConstraintType(Constraint);
+}
+
 std::pair<unsigned, const TargetRegisterClass *>
 BPFTargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
                                                 StringRef Constraint,
@@ -211,6 +225,10 @@ BPFTargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
     switch (Constraint[0]) {
     case 'r': // GENERAL_REGS
       return std::make_pair(0U, &BPF::GPRRegClass);
+    case 'w':
+      if (HasAlu32)
+        return std::make_pair(0U, &BPF::GPR32RegClass);
+      break;
     default:
       break;
     }

--- a/llvm/lib/Target/BPF/BPFISelLowering.h
+++ b/llvm/lib/Target/BPF/BPFISelLowering.h
@@ -46,6 +46,9 @@ public:
   // with the given GlobalAddress is legal.
   bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const override;
 
+  BPFTargetLowering::ConstraintType
+  getConstraintType(StringRef Constraint) const override;
+
   std::pair<unsigned, const TargetRegisterClass *>
   getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
                                StringRef Constraint, MVT VT) const override;

--- a/llvm/test/CodeGen/BPF/inlineasm-wreg.ll
+++ b/llvm/test/CodeGen/BPF/inlineasm-wreg.ll
@@ -1,0 +1,18 @@
+; RUN: llc < %s -march=bpfel -mattr=+alu32 -verify-machineinstrs | FileCheck %s
+; RUN: llc < %s -march=bpfeb -mattr=+alu32 -verify-machineinstrs | FileCheck %s
+
+; Test that %w works as input constraint
+; CHECK-LABEL: test_inlineasm_w_input_constraint
+define dso_local i32 @test_inlineasm_w_input_constraint() {
+  tail call void asm sideeffect "w0 = $0", "w"(i32 42)
+; CHECK: w0 = w1
+  ret i32 42
+}
+
+; Test that %w works as output constraint
+; CHECK-LABEL: test_inlineasm_w_output_constraint
+define dso_local i32 @test_inlineasm_w_output_constraint() {
+  %1 = tail call i32 asm sideeffect "$0 = $1", "=w,i"(i32 42)
+; CHECK: w0 = 42
+  ret i32 %1
+}


### PR DESCRIPTION
This cherry-picks https://github.com/llvm/llvm-project/commit/833e9b2ea7a7290f8833d524c8f8865558c1016a and is needed by https://github.com/rust-lang/rust/pull/79608