### PR TITLE
[NewPM] Add missing LTO ArgPromotion pass

### DIFF
--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -1784,8 +1784,11 @@ PassBuilder::buildLTODefaultPipeline(OptimizationLevel Level,
   MPM.addPass(GlobalOptPass());
 
   // Garbage collect dead functions.
-  // FIXME: Add ArgumentPromotion pass after once it's ported.
   MPM.addPass(GlobalDCEPass());
+
+  // If we didn't decide to inline a function, check to see if we can
+  // transform it to pass arguments by value instead of by reference.
+  MPM.addPass(createModuleToPostOrderCGSCCPassAdaptor(ArgumentPromotionPass()));
 
   FunctionPassManager FPM;
   // The IPO Passes may leave cruft around. Clean up after them.

--- a/llvm/test/Other/new-pm-lto-defaults.ll
+++ b/llvm/test/Other/new-pm-lto-defaults.ll
@@ -73,6 +73,7 @@
 ; CHECK-O23SZ-NEXT: Running pass: InlinerPass
 ; CHECK-O23SZ-NEXT: Running pass: GlobalOptPass
 ; CHECK-O23SZ-NEXT: Running pass: GlobalDCEPass
+; CHECK-O23SZ-NEXT: Running pass: ArgumentPromotionPass
 ; CHECK-O23SZ-NEXT: Running pass: InstCombinePass
 ; CHECK-EP-Peephole-NEXT: Running pass: NoOpFunctionPass
 ; CHECK-O23SZ-NEXT: Running pass: JumpThreadingPass


### PR DESCRIPTION
This is a followup to D96780 to add one more pass missing from the
NewPM LTO pipeline. The missing ArgPromotion run is inserted at
the same position as in the LegacyPM, resolving the already
present FIXME:
https://github.com/llvm/llvm-project/blob/16086d47c0d0cd08ffae8e69a69c88653e654d01/llvm/lib/Transforms/IPO/PassManagerBuilder.cpp#L1096-L1098

The compile-time impact is minimal with ~0.1% geomean regression
on CTMark.

Differential Revision: https://reviews.llvm.org/D108866

(cherry picked from commit b28c3b9d9f4292d7779a0e2661d308f1230c6ecd)

-----

Upstream backport requested in https://bugs.llvm.org/show_bug.cgi?id=51664. This is intended to unblock https://github.com/rust-lang/rust/pull/88243.