### PR TITLE
[cherry-pick] Fix MIPS FPU comparisons

### DIFF
--- a/llvm/lib/Target/Mips/MipsInstrInfo.h
+++ b/llvm/lib/Target/Mips/MipsInstrInfo.h
@@ -92,8 +92,15 @@ public:
   /// Predicate to determine if an instruction can go in a forbidden slot.
   bool SafeInForbiddenSlot(const MachineInstr &MI) const;
 
+  /// Predicate to determine if an instruction can go in an FPU delay slot.
+  bool SafeInFPUDelaySlot(const MachineInstr &MIInSlot,
+                          const MachineInstr &FPUMI) const;
+
   /// Predicate to determine if an instruction has a forbidden slot.
   bool HasForbiddenSlot(const MachineInstr &MI) const;
+
+  /// Predicate to determine if an instruction has an FPU delay slot.
+  bool HasFPUDelaySlot(const MachineInstr &MI) const;
 
   /// Insert nop instruction when hazard condition is found
   void insertNoop(MachineBasicBlock &MBB,

--- a/llvm/test/CodeGen/Mips/llvm-ir/select-dbl.ll
+++ b/llvm/test/CodeGen/Mips/llvm-ir/select-dbl.ll
@@ -203,6 +203,7 @@ define double @tst_select_fcmp_olt_double(double %x, double %y) {
 ; M2-LABEL: tst_select_fcmp_olt_double:
 ; M2:       # %bb.0: # %entry
 ; M2-NEXT:    c.olt.d $f12, $f14
+; M2-NEXT:    nop
 ; M2-NEXT:    bc1t $BB2_2
 ; M2-NEXT:    mov.d $f0, $f12
 ; M2-NEXT:  # %bb.1: # %entry
@@ -236,6 +237,7 @@ define double @tst_select_fcmp_olt_double(double %x, double %y) {
 ; M3-LABEL: tst_select_fcmp_olt_double:
 ; M3:       # %bb.0: # %entry
 ; M3-NEXT:    c.olt.d $f12, $f13
+; M3-NEXT:    nop
 ; M3-NEXT:    bc1t .LBB2_2
 ; M3-NEXT:    mov.d $f0, $f12
 ; M3-NEXT:  # %bb.1: # %entry
@@ -283,6 +285,7 @@ define double @tst_select_fcmp_ole_double(double %x, double %y) {
 ; M2-LABEL: tst_select_fcmp_ole_double:
 ; M2:       # %bb.0: # %entry
 ; M2-NEXT:    c.ole.d $f12, $f14
+; M2-NEXT:    nop
 ; M2-NEXT:    bc1t $BB3_2
 ; M2-NEXT:    mov.d $f0, $f12
 ; M2-NEXT:  # %bb.1: # %entry
@@ -316,6 +319,7 @@ define double @tst_select_fcmp_ole_double(double %x, double %y) {
 ; M3-LABEL: tst_select_fcmp_ole_double:
 ; M3:       # %bb.0: # %entry
 ; M3-NEXT:    c.ole.d $f12, $f13
+; M3-NEXT:    nop
 ; M3-NEXT:    bc1t .LBB3_2
 ; M3-NEXT:    mov.d $f0, $f12
 ; M3-NEXT:  # %bb.1: # %entry
@@ -363,6 +367,7 @@ define double @tst_select_fcmp_ogt_double(double %x, double %y) {
 ; M2-LABEL: tst_select_fcmp_ogt_double:
 ; M2:       # %bb.0: # %entry
 ; M2-NEXT:    c.ule.d $f12, $f14
+; M2-NEXT:    nop
 ; M2-NEXT:    bc1f $BB4_2
 ; M2-NEXT:    mov.d $f0, $f12
 ; M2-NEXT:  # %bb.1: # %entry
@@ -396,6 +401,7 @@ define double @tst_select_fcmp_ogt_double(double %x, double %y) {
 ; M3-LABEL: tst_select_fcmp_ogt_double:
 ; M3:       # %bb.0: # %entry
 ; M3-NEXT:    c.ule.d $f12, $f13
+; M3-NEXT:    nop
 ; M3-NEXT:    bc1f .LBB4_2
 ; M3-NEXT:    mov.d $f0, $f12
 ; M3-NEXT:  # %bb.1: # %entry
@@ -443,6 +449,7 @@ define double @tst_select_fcmp_oge_double(double %x, double %y) {
 ; M2-LABEL: tst_select_fcmp_oge_double:
 ; M2:       # %bb.0: # %entry
 ; M2-NEXT:    c.ult.d $f12, $f14
+; M2-NEXT:    nop
 ; M2-NEXT:    bc1f $BB5_2
 ; M2-NEXT:    mov.d $f0, $f12
 ; M2-NEXT:  # %bb.1: # %entry
@@ -476,6 +483,7 @@ define double @tst_select_fcmp_oge_double(double %x, double %y) {
 ; M3-LABEL: tst_select_fcmp_oge_double:
 ; M3:       # %bb.0: # %entry
 ; M3-NEXT:    c.ult.d $f12, $f13
+; M3-NEXT:    nop
 ; M3-NEXT:    bc1f .LBB5_2
 ; M3-NEXT:    mov.d $f0, $f12
 ; M3-NEXT:  # %bb.1: # %entry
@@ -523,6 +531,7 @@ define double @tst_select_fcmp_oeq_double(double %x, double %y) {
 ; M2-LABEL: tst_select_fcmp_oeq_double:
 ; M2:       # %bb.0: # %entry
 ; M2-NEXT:    c.eq.d $f12, $f14
+; M2-NEXT:    nop
 ; M2-NEXT:    bc1t $BB6_2
 ; M2-NEXT:    mov.d $f0, $f12
 ; M2-NEXT:  # %bb.1: # %entry
@@ -556,6 +565,7 @@ define double @tst_select_fcmp_oeq_double(double %x, double %y) {
 ; M3-LABEL: tst_select_fcmp_oeq_double:
 ; M3:       # %bb.0: # %entry
 ; M3-NEXT:    c.eq.d $f12, $f13
+; M3-NEXT:    nop
 ; M3-NEXT:    bc1t .LBB6_2
 ; M3-NEXT:    mov.d $f0, $f12
 ; M3-NEXT:  # %bb.1: # %entry
@@ -603,6 +613,7 @@ define double @tst_select_fcmp_one_double(double %x, double %y) {
 ; M2-LABEL: tst_select_fcmp_one_double:
 ; M2:       # %bb.0: # %entry
 ; M2-NEXT:    c.ueq.d $f12, $f14
+; M2-NEXT:    nop
 ; M2-NEXT:    bc1f $BB7_2
 ; M2-NEXT:    mov.d $f0, $f12
 ; M2-NEXT:  # %bb.1: # %entry
@@ -637,6 +648,7 @@ define double @tst_select_fcmp_one_double(double %x, double %y) {
 ; M3-LABEL: tst_select_fcmp_one_double:
 ; M3:       # %bb.0: # %entry
 ; M3-NEXT:    c.ueq.d $f12, $f13
+; M3-NEXT:    nop
 ; M3-NEXT:    bc1f .LBB7_2
 ; M3-NEXT:    mov.d $f0, $f12
 ; M3-NEXT:  # %bb.1: # %entry

--- a/llvm/test/CodeGen/Mips/llvm-ir/select-flt.ll
+++ b/llvm/test/CodeGen/Mips/llvm-ir/select-flt.ll
@@ -189,6 +189,7 @@ define float @tst_select_fcmp_olt_float(float %x, float %y) {
 ; M2-LABEL: tst_select_fcmp_olt_float:
 ; M2:       # %bb.0: # %entry
 ; M2-NEXT:    c.olt.s $f12, $f14
+; M2-NEXT:    nop
 ; M2-NEXT:    bc1t $BB2_2
 ; M2-NEXT:    mov.s $f0, $f12
 ; M2-NEXT:  # %bb.1: # %entry
@@ -220,6 +221,7 @@ define float @tst_select_fcmp_olt_float(float %x, float %y) {
 ; M3-LABEL: tst_select_fcmp_olt_float:
 ; M3:       # %bb.0: # %entry
 ; M3-NEXT:    c.olt.s $f12, $f13
+; M3-NEXT:    nop
 ; M3-NEXT:    bc1t .LBB2_2
 ; M3-NEXT:    mov.s $f0, $f12
 ; M3-NEXT:  # %bb.1: # %entry
@@ -263,6 +265,7 @@ define float @tst_select_fcmp_ole_float(float %x, float %y) {
 ; M2-LABEL: tst_select_fcmp_ole_float:
 ; M2:       # %bb.0: # %entry
 ; M2-NEXT:    c.ole.s $f12, $f14
+; M2-NEXT:    nop
 ; M2-NEXT:    bc1t $BB3_2
 ; M2-NEXT:    mov.s $f0, $f12
 ; M2-NEXT:  # %bb.1: # %entry
@@ -294,6 +297,7 @@ define float @tst_select_fcmp_ole_float(float %x, float %y) {
 ; M3-LABEL: tst_select_fcmp_ole_float:
 ; M3:       # %bb.0: # %entry
 ; M3-NEXT:    c.ole.s $f12, $f13
+; M3-NEXT:    nop
 ; M3-NEXT:    bc1t .LBB3_2
 ; M3-NEXT:    mov.s $f0, $f12
 ; M3-NEXT:  # %bb.1: # %entry
@@ -337,6 +341,7 @@ define float @tst_select_fcmp_ogt_float(float %x, float %y) {
 ; M2-LABEL: tst_select_fcmp_ogt_float:
 ; M2:       # %bb.0: # %entry
 ; M2-NEXT:    c.ule.s $f12, $f14
+; M2-NEXT:    nop
 ; M2-NEXT:    bc1f $BB4_2
 ; M2-NEXT:    mov.s $f0, $f12
 ; M2-NEXT:  # %bb.1: # %entry
@@ -368,6 +373,7 @@ define float @tst_select_fcmp_ogt_float(float %x, float %y) {
 ; M3-LABEL: tst_select_fcmp_ogt_float:
 ; M3:       # %bb.0: # %entry
 ; M3-NEXT:    c.ule.s $f12, $f13
+; M3-NEXT:    nop
 ; M3-NEXT:    bc1f .LBB4_2
 ; M3-NEXT:    mov.s $f0, $f12
 ; M3-NEXT:  # %bb.1: # %entry
@@ -411,6 +417,7 @@ define float @tst_select_fcmp_oge_float(float %x, float %y) {
 ; M2-LABEL: tst_select_fcmp_oge_float:
 ; M2:       # %bb.0: # %entry
 ; M2-NEXT:    c.ult.s $f12, $f14
+; M2-NEXT:    nop
 ; M2-NEXT:    bc1f $BB5_2
 ; M2-NEXT:    mov.s $f0, $f12
 ; M2-NEXT:  # %bb.1: # %entry
@@ -442,6 +449,7 @@ define float @tst_select_fcmp_oge_float(float %x, float %y) {
 ; M3-LABEL: tst_select_fcmp_oge_float:
 ; M3:       # %bb.0: # %entry
 ; M3-NEXT:    c.ult.s $f12, $f13
+; M3-NEXT:    nop
 ; M3-NEXT:    bc1f .LBB5_2
 ; M3-NEXT:    mov.s $f0, $f12
 ; M3-NEXT:  # %bb.1: # %entry
@@ -485,6 +493,7 @@ define float @tst_select_fcmp_oeq_float(float %x, float %y) {
 ; M2-LABEL: tst_select_fcmp_oeq_float:
 ; M2:       # %bb.0: # %entry
 ; M2-NEXT:    c.eq.s $f12, $f14
+; M2-NEXT:    nop
 ; M2-NEXT:    bc1t $BB6_2
 ; M2-NEXT:    mov.s $f0, $f12
 ; M2-NEXT:  # %bb.1: # %entry
@@ -516,6 +525,7 @@ define float @tst_select_fcmp_oeq_float(float %x, float %y) {
 ; M3-LABEL: tst_select_fcmp_oeq_float:
 ; M3:       # %bb.0: # %entry
 ; M3-NEXT:    c.eq.s $f12, $f13
+; M3-NEXT:    nop
 ; M3-NEXT:    bc1t .LBB6_2
 ; M3-NEXT:    mov.s $f0, $f12
 ; M3-NEXT:  # %bb.1: # %entry
@@ -559,6 +569,7 @@ define float @tst_select_fcmp_one_float(float %x, float %y) {
 ; M2-LABEL: tst_select_fcmp_one_float:
 ; M2:       # %bb.0: # %entry
 ; M2-NEXT:    c.ueq.s $f12, $f14
+; M2-NEXT:    nop
 ; M2-NEXT:    bc1f $BB7_2
 ; M2-NEXT:    mov.s $f0, $f12
 ; M2-NEXT:  # %bb.1: # %entry
@@ -593,6 +604,7 @@ define float @tst_select_fcmp_one_float(float %x, float %y) {
 ; M3-LABEL: tst_select_fcmp_one_float:
 ; M3:       # %bb.0: # %entry
 ; M3-NEXT:    c.ueq.s $f12, $f13
+; M3-NEXT:    nop
 ; M3-NEXT:    bc1f .LBB7_2
 ; M3-NEXT:    mov.s $f0, $f12
 ; M3-NEXT:  # %bb.1: # %entry


### PR DESCRIPTION
This patch fixes FPU register moves/comparisons for MIPS1/2/3 targets. Currently, `rustc` by way of LLVM generates broken code for the `mipsel-sony-psp` target when using [Rust-PSP](https://github.com/overdrivenpotato/rust-psp). [The LLVM patch](https://reviews.llvm.org/rGf0f6bba5b285632577fd77aa802b07d927f2573e) goes over the details.