### PR TITLE
Add Rust to CodeView SourceLanguage (CV_CFL_LANG) enum

### DIFF
--- a/llvm/include/llvm/DebugInfo/CodeView/CodeView.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/CodeView.h
@@ -162,6 +162,8 @@ enum SourceLanguage : uint8_t {
   MSIL = 0x0f,
   HLSL = 0x10,
 
+  Rust = 0x15,
+
   /// The DMD & Swift compilers emit 'D' and 'S', respectively, for the CV
   /// source language. Microsoft does not have enumerators for them yet.
   D = 'D',

--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
@@ -760,6 +760,8 @@ static SourceLanguage MapDWLangToCVLang(unsigned DWLang) {
     return SourceLanguage::D;
   case dwarf::DW_LANG_Swift:
     return SourceLanguage::Swift;
+  case dwarf::DW_LANG_Rust:
+    return SourceLanguage::Rust;
   default:
     // There's no CodeView representation for this language, and CV doesn't
     // have an "unknown" option for the language field, so we'll use MASM,

--- a/llvm/lib/DebugInfo/CodeView/EnumTables.cpp
+++ b/llvm/lib/DebugInfo/CodeView/EnumTables.cpp
@@ -104,7 +104,7 @@ static const EnumEntry<codeview::SourceLanguage> SourceLanguages[] = {
     CV_ENUM_ENT(SourceLanguage, ILAsm),   CV_ENUM_ENT(SourceLanguage, Java),
     CV_ENUM_ENT(SourceLanguage, JScript), CV_ENUM_ENT(SourceLanguage, MSIL),
     CV_ENUM_ENT(SourceLanguage, HLSL),    CV_ENUM_ENT(SourceLanguage, D),
-    CV_ENUM_ENT(SourceLanguage, Swift),
+    CV_ENUM_ENT(SourceLanguage, Swift),   CV_ENUM_ENT(SourceLanguage, Rust),
 };
 
 static const EnumEntry<uint32_t> CompileSym2FlagNames[] = {

--- a/llvm/lib/DebugInfo/PDB/PDBExtras.cpp
+++ b/llvm/lib/DebugInfo/PDB/PDBExtras.cpp
@@ -231,6 +231,7 @@ raw_ostream &llvm::pdb::operator<<(raw_ostream &OS, const PDB_Lang &Lang) {
     CASE_OUTPUT_ENUM_CLASS_NAME(PDB_Lang, HLSL, OS)
     CASE_OUTPUT_ENUM_CLASS_NAME(PDB_Lang, D, OS)
     CASE_OUTPUT_ENUM_CLASS_NAME(PDB_Lang, Swift, OS)
+    CASE_OUTPUT_ENUM_CLASS_NAME(PDB_Lang, Rust, OS)
   }
   return OS;
 }

--- a/llvm/lib/DebugInfo/PDB/PDBSymbolCompiland.cpp
+++ b/llvm/lib/DebugInfo/PDB/PDBSymbolCompiland.cpp
@@ -100,6 +100,7 @@ std::string PDBSymbolCompiland::getSourceFileFullPath() const {
               .Case(".c", Lang == PDB_Lang::C)
               .Case(".asm", Lang == PDB_Lang::Masm)
               .Case(".swift", Lang == PDB_Lang::Swift)
+              .Case(".rs", Lang == PDB_Lang::Rust)
               .Default(false))
         return File->getFileName();
     }

--- a/llvm/test/DebugInfo/COFF/rust.ll
+++ b/llvm/test/DebugInfo/COFF/rust.ll
@@ -1,0 +1,48 @@
+; RUN: llc < %s | FileCheck %s --check-prefix=ASM
+; RUN: llc -filetype=obj < %s | llvm-readobj --codeview - | FileCheck %s --check-prefix=OBJ
+
+; ASM:      .short  4412                    # Record kind: S_COMPILE3
+; ASM-NEXT: .long   21                      # Flags and language
+; ASM-NEXT: .short  208                     # CPUType
+
+; OBJ-LABEL: Compile3Sym {
+; OBJ-NEXT:    Kind: S_COMPILE3 (0x113C)
+; OBJ-NEXT:    Language: Rust (0x15)
+; OBJ-NEXT:    Flags [ (0x0)
+; OBJ-NEXT:    ]
+; OBJ-NEXT:    Machine: X64 (0xD0)
+; OBJ-NEXT:    FrontendVersion: {{[0-9.]*}}
+; OBJ-NEXT:    BackendVersion: {{[0-9.]*}}
+; OBJ-NEXT:    VersionName: clang LLVM (rustc version 1.57.0 (f1edd0429 2021-11-29))
+; OBJ-NEXT:  }
+
+
+; ModuleID = 'main.a61fec89-cgu.0'
+source_filename = "main.a61fec89-cgu.0"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+; Function Attrs: uwtable
+define void @f() unnamed_addr #0 !dbg !6 {
+start:
+  ret void, !dbg !11
+}
+
+attributes #0 = { uwtable "target-cpu"="x86-64" }
+
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.dbg.cu = !{!3}
+
+!0 = !{i32 7, !"PIC Level", i32 2}
+!1 = !{i32 2, !"CodeView", i32 1}
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !4, producer: "clang LLVM (rustc version 1.57.0 (f1edd0429 2021-11-29))", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !5)
+!4 = !DIFile(filename: "main.rs", directory: "src")
+!5 = !{}
+!6 = distinct !DISubprogram(name: "f", scope: !8, file: !7, line: 13, type: !9, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, templateParams: !5, retainedNodes: !5)
+!7 = !DIFile(filename: "main.rs", directory: "src", checksumkind: CSK_SHA1, checksum: "2ac9107db410c2ac03093f537ff521068091fb92")
+!8 = !DINamespace(name: "main", scope: null)
+!9 = !DISubroutineType(types: !10)
+!10 = !{null}
+!11 = !DILocation(line: 14, scope: !12)
+!12 = !DILexicalBlockFile(scope: !6, file: !7, discriminator: 0)

--- a/llvm/tools/llvm-pdbutil/MinimalSymbolDumper.cpp
+++ b/llvm/tools/llvm-pdbutil/MinimalSymbolDumper.cpp
@@ -207,6 +207,7 @@ static std::string formatSourceLanguage(SourceLanguage Lang) {
     RETURN_CASE(SourceLanguage, HLSL, "hlsl");
     RETURN_CASE(SourceLanguage, D, "d");
     RETURN_CASE(SourceLanguage, Swift, "swift");
+    RETURN_CASE(SourceLanguage, Rust, "rust");
   }
   return formatUnknownEnum(Lang);
 }


### PR DESCRIPTION
Cherry picks a recent change to LLVM that gives Rust its own identifier in the PDB format. Rust-compiled objects currently show as MASM (Microsoft Assembler) in PDB analysis tooling on Windows.

LLVM Differential Revision: https://reviews.llvm.org/D115300