### PR TITLE
[Mangler] Mangle aliases to fastcall/vectorcall functions correctly

### DIFF
--- a/llvm/lib/IR/Mangler.cpp
+++ b/llvm/lib/IR/Mangler.cpp
@@ -144,7 +144,7 @@ void Mangler::getNameWithPrefix(raw_ostream &OS, const GlobalValue *GV,
 
   // Mangle functions with Microsoft calling conventions specially.  Only do
   // this mangling for x86_64 vectorcall and 32-bit x86.
-  const Function *MSFunc = dyn_cast<Function>(GV);
+  const Function *MSFunc = dyn_cast_or_null<Function>(GV->getAliaseeObject());
 
   // Don't add byte count suffixes when '\01' or '?' are in the first
   // character.

--- a/llvm/test/CodeGen/X86/fastcall-correct-mangling.ll
+++ b/llvm/test/CodeGen/X86/fastcall-correct-mangling.ll
@@ -31,3 +31,7 @@ define private x86_fastcallcc void @dontCrash() {
 ; CHECK64-LABEL: {{^}}.LdontCrash:
   ret void
 }
+
+@alias = alias void(i64, i8, i8, i16), void(i64, i8, i8, i16)* @func
+; CHECK32-LABEL: {{^}}.set @alias@20, @func@20
+; CHECK64-LABEL: {{^}}.set alias, func


### PR DESCRIPTION
These aliases are produced by MergeFunctions and need to be mangled according to the calling convention of the function they are pointing to instead of defaulting to the C calling convention.

Reviewed By: rnk

Differential Revision: https://reviews.llvm.org/D120382