### PR TITLE
Cherry-pick: [AVR] Fix expanding MOVW for overlapping registers

### DIFF
--- a/llvm/test/CodeGen/AVR/pseudo/COPY.mir
+++ b/llvm/test/CodeGen/AVR/pseudo/COPY.mir
@@ -1,0 +1,47 @@
+# RUN: llc -O0 %s -o - | FileCheck %s
+
+--- |
+  target triple = "avr--"
+
+  define void @test_copy_nonoverlapping() {
+  entry:
+    ret void
+  }
+
+  define void @test_copy_overlapping() {
+  entry:
+    ret void
+  }
+
+  declare void @foo(i16 %0)
+...
+
+---
+name: test_copy_nonoverlapping
+tracksRegLiveness: true
+body: |
+  bb.0.entry:
+    liveins: $r25r24
+
+    ; CHECK-LABEL: test_copy_nonoverlapping:
+    ; CHECK: mov r22, r24
+    ; CHECK-NEXT: mov r23, r25
+
+    $r23r22 = COPY $r25r24
+    RCALLk @foo, implicit $r24r23
+...
+
+---
+name: test_copy_overlapping
+tracksRegLiveness: true
+body: |
+  bb.0.entry:
+    liveins: $r24r23
+
+    ; CHECK-LABEL: test_copy_overlapping:
+    ; CHECK: mov r25, r24
+    ; CHECK-NEXT: mov r24, r23
+
+    $r25r24 = COPY $r24r23
+    RCALLk @foo, implicit $r25r24
+...

--- a/llvm/test/CodeGen/AVR/rust-bug-98167.ll
+++ b/llvm/test/CodeGen/AVR/rust-bug-98167.ll
@@ -1,0 +1,22 @@
+; RUN: llc < %s -march=avr | FileCheck %s
+
+; The bug can be found here:
+; https://github.com/rust-lang/rust/issues/98167
+;
+; In this test, `extractvalue` + `call` generate a copy with overlapping
+; registers (`$r25r24 = COPY $r24r23`) that used to be expanded incorrectly.
+
+define void @main() {
+; CHECK-LABEL: main:
+; CHECK: rcall foo
+; CHECK-NEXT: mov r25, r24
+; CHECK-NEXT: mov r24, r23
+; CHECK-NEXT: rcall bar
+  %1 = call { i8, i16 } @foo()
+  %2 = extractvalue { i8, i16 } %1, 1
+  call void @bar(i16 %2)
+  ret void
+}
+
+declare { i8, i16 } @foo()
+declare void @bar(i16 %0)


### PR DESCRIPTION
Cherry-pick of https://github.com/llvm/llvm-project/commit/5650688e7242b31b1447189176493aa12c99f355 (accepted & merged in https://reviews.llvm.org/D128588) that'll fix https://github.com/rust-lang/rust/issues/98167.