### PR TITLE
Adapt "[M68k] Fix ODR violation in GISel code" to LLVM 17

### DIFF
--- a/llvm/lib/Target/M68k/GISel/M68kCallLowering.cpp
+++ b/llvm/lib/Target/M68k/GISel/M68kCallLowering.cpp
@@ -39,7 +39,7 @@ struct CallReturnHandler : public M68kIncomingValueHandler {
 
 private:
   void assignValueToReg(Register ValVReg, Register PhysReg,
-                        const CCValAssign &VA) override;
+                        const CCValAssign VA) override;
 
   MachineInstrBuilder &MIB;
 };


### PR DESCRIPTION
This time tested with `x.py build` as a part of https://github.com/rust-lang/rust/pull/119159 with all the relevant targets enabled.

Addresses https://github.com/rust-lang/llvm-project/pull/159#discussion_r1432608221.