### PR TITLE
Cherry-pick "[MC][AsmParser] Diagnose improperly nested .cfi frames"

### DIFF
--- a/lld/test/COFF/gc-dwarf-eh.s
+++ b/lld/test/COFF/gc-dwarf-eh.s
@@ -13,9 +13,9 @@
 	.def	_main; .scl	2; .type	32; .endef
 	.section	.text,"xr",one_only,_main
 	.globl	_main
+_main:
 	.cfi_startproc
 	.cfi_personality 0, ___gxx_personality_v0
-_main:
 	xorl	%eax, %eax
 	ret
 	.cfi_endproc
@@ -29,8 +29,8 @@ ___gxx_personality_v0:
 	.def	_unused; .scl	2; .type	32; .endef
 	.section	.text,"xr",one_only,_unused
 	.globl	_unused
+_unused:
 	.cfi_startproc
 	.cfi_personality 0, ___gxx_personality_v0
-_unused:
 	ret
 	.cfi_endproc

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -125,6 +125,7 @@ private:
   void *SavedDiagContext;
   std::unique_ptr<MCAsmParserExtension> PlatformParser;
   SMLoc StartTokLoc;
+  std::optional<SMLoc> CFIStartProcLoc;
 
   /// This is the current buffer index we're lexing from as managed by the
   /// SourceMgr object.
@@ -1948,6 +1949,11 @@ bool AsmParser::parseStatement(ParseStatementInfo &Info,
     if (getTok().is(AsmToken::EndOfStatement)) {
       Lex();
     }
+
+    if (MAI.hasSubsectionsViaSymbols() && CFIStartProcLoc && Sym->isExternal())
+      return Error(StartTokLoc, "non-private labels cannot appear between "
+                                ".cfi_startproc / .cfi_endproc pairs") &&
+             Error(*CFIStartProcLoc, "previous .cfi_startproc was here");
 
     if (discardLTOSymbol(IDVal))
       return false;
@@ -4181,6 +4187,8 @@ bool AsmParser::parseDirectiveCFISections() {
 /// parseDirectiveCFIStartProc
 /// ::= .cfi_startproc [simple]
 bool AsmParser::parseDirectiveCFIStartProc() {
+  CFIStartProcLoc = StartTokLoc;
+
   StringRef Simple;
   if (!parseOptionalToken(AsmToken::EndOfStatement)) {
     if (check(parseIdentifier(Simple) || Simple != "simple",
@@ -4201,8 +4209,11 @@ bool AsmParser::parseDirectiveCFIStartProc() {
 /// parseDirectiveCFIEndProc
 /// ::= .cfi_endproc
 bool AsmParser::parseDirectiveCFIEndProc() {
+  CFIStartProcLoc = std::nullopt;
+
   if (parseEOL())
     return true;
+
   getStreamer().emitCFIEndProc();
   return false;
 }

--- a/llvm/test/MC/AArch64/cfi-bad-nesting-darwin.s
+++ b/llvm/test/MC/AArch64/cfi-bad-nesting-darwin.s
@@ -1,0 +1,24 @@
+; RUN: not llvm-mc -triple arm64-apple-darwin %s -filetype=obj -o /dev/null 2>&1 | FileCheck %s --check-prefix=DARWIN
+
+; REQUIRES: aarch64-registered-target
+
+	.section	__TEXT,locomotive,regular,pure_instructions
+
+	.globl	_locomotive
+	.p2align	2
+_locomotive:
+	.cfi_startproc
+	ret
+
+	; It is invalid to have a non-private label between .cfi_startproc and
+	; .cfi_endproc on MachO platforms.
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_caboose
+	.p2align	2
+_caboose:
+; DARWIN: [[#@LINE-1]]:1: error: non-private labels cannot appear between .cfi_startproc / .cfi_endproc pairs
+; DARWIN: [[#@LINE-10]]:2: error: previous .cfi_startproc was here
+	ret
+	.cfi_endproc
+
+.subsections_via_symbols

--- a/llvm/test/MC/AArch64/cfi-bad-nesting-elf.s
+++ b/llvm/test/MC/AArch64/cfi-bad-nesting-elf.s
@@ -1,0 +1,20 @@
+# RUN: llvm-mc -triple arm64-pc-linux-gnu %s -filetype=obj -o /dev/null 2>&1 | FileCheck %s --allow-empty --check-prefix=ELF
+# RUN: llvm-mc -triple arm64-windows-gnu %s -filetype=obj -o /dev/null 2>&1 | FileCheck %s --allow-empty --check-prefix=ELF
+
+# REQUIRES: aarch64-registered-target
+
+	.globl	_locomotive
+	.p2align	2
+_locomotive:
+	.cfi_startproc
+	ret
+
+	.globl	_caboose
+	.p2align	2
+_caboose:
+	ret
+	.cfi_endproc
+
+# Check that the diagnostic does not fire on ELF, nor COFF platforms, which do
+# not support subsections_via_symbols. See also: cfi-bad-nesting-darwin.s
+# ELF-NOT: error:


### PR DESCRIPTION
Cherry pick of d506aa4edfa66074db3dc1fa84da9d9c80d71500. This fixes llvm/llvm-project#72802, which manifests in the Rust build as failure to build compiler_builtins when targeting macos in some configurations.