### PR TITLE
Cherry-pick: [builtins] Move cfi start's after the symbol name [NFC]

### DIFF
--- a/compiler-rt/lib/builtins/assembly.h
+++ b/compiler-rt/lib/builtins/assembly.h
@@ -260,9 +260,10 @@
   .globl name SEPARATOR                                                        \
   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
-  CFI_START SEPARATOR                                                          \
   DECLARE_FUNC_ENCODING                                                        \
-  name: SEPARATOR BTI_C
+  name:                                                                        \
+  SEPARATOR CFI_START                                                          \
+  SEPARATOR BTI_C
 
 #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
   .globl SYMBOL_NAME(name) SEPARATOR                                           \


### PR DESCRIPTION
... in preparation for diagnosing improperly nested .cfi regions.

See https://reviews.llvm.org/D155245

---

This cherry-pick of 7939ce39dac0078fef7183d6198598b99c652c88 fixes an issue when building compiler-builtins with clang from LLVM main. The check in the linked diff / commit d506aa4edfa66074db3dc1fa84da9d9c80d71500 rejects the assembly due to improperly nested CFI regions:

```
  running: env -u IPHONEOS_DEPLOYMENT_TARGET "/Volumes/Work/s/w/ir/x/w/cipd/bin/clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=arm64-apple-darwin" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=arm64-apple-darwin" "--target=aarch64-apple-darwin" "--sysroot=/Volumes/Work/s/w/ir/cache/macos_sdk/XCode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk" "-mno-outline-atomics" "-I" "/Volumes/Work/s/w/ir/x/w/fuchsia-third_party-rust/src/llvm-project/compiler-rt/lib/builtins" "-fno-builtin" "-fvisibility=hidden" "-ffreestanding" "-fomit-frame-pointer" "-ffile-prefix-map=/Volumes/Work/s/w/ir/x/w/fuchsia-third_party-rust/src/llvm-project/compiler-rt=." "-DVISIBILITY_HIDDEN" "-o" "/Volumes/Work/s/w/ir/x/w/staging/build/fuchsia-build/x86_64-apple-darwin/stage2-std/aarch64-apple-darwin/release/build/compiler_builtins-d4c39d93f1fd5499/out/657ee1fe8a0b7177-lse_cas1_relax.o" "-c" "/Volumes/Work/s/w/ir/x/w/staging/build/fuchsia-build/x86_64-apple-darwin/stage2-std/aarch64-apple-darwin/release/build/compiler_builtins-d4c39d93f1fd5499/out/lse_cas1_relax.S"
  cargo:warning=/Volumes/Work/s/w/ir/x/w/fuchsia-third_party-rust/src/llvm-project/compiler-rt/lib/builtins/aarch64/lse.S:145:120: error: non-private labels cannot appear between .cfi_startproc / .cfi_endproc pairs
  cargo:warning= .text %% .balign 16 %% .globl __aarch64_cas1_relax %% %% .private_extern __aarch64_cas1_relax %% %% .cfi_startproc %% __aarch64_cas1_relax: %%
  cargo:warning=                                                                                                                       ^
  cargo:warning=/Volumes/Work/s/w/ir/x/w/fuchsia-third_party-rust/src/llvm-project/compiler-rt/lib/builtins/aarch64/lse.S:145:102: error: previous .cfi_startproc was here
  cargo:warning= .text %% .balign 16 %% .globl __aarch64_cas1_relax %% %% .private_extern __aarch64_cas1_relax %% %% .cfi_startproc %% __aarch64_cas1_relax: %%
  cargo:warning=                                                                                                     ^
  exit status: 1
```