### PR TITLE
Backport [ADT] Add `<cstdint>` to SmallVector (#101761)

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <functional>


### PR DESCRIPTION
Downstream bug:  https://bugs.gentoo.org/937525

Fixes build with gcc-15.  CC @thesamesam

```
Author: Sam James <sam@gentoo.org>
Date:   Fri Aug 2 23:07:21 2024 +0100

    [ADT] Add `<cstdint>` to SmallVector (#101761)
    
    SmallVector uses `uint32_t`, `uint64_t` without including `<cstdint>`
    which fails to build w/ GCC 15 after a change in libstdc++ [0]
    
    [0] https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=3a817a4a5a6d94da9127af3be9f84a74e3076ee2

 llvm/include/llvm/ADT/SmallVector.h | 1 +
 1 file changed, 1 insertion(+)
```