### PR TITLE
Revert "[rust] Comment out __builtin_available() use (#21)"

### DIFF
--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1491,7 +1491,7 @@ namespace fs {
 std::error_code copy_file(const Twine &From, const Twine &To) {
   std::string FromS = From.str();
   std::string ToS = To.str();
-#if 0 && __has_builtin(__builtin_available)
+#if __has_builtin(__builtin_available)
   if (__builtin_available(macos 10.12, *)) {
     // Optimistically try to use clonefile() and handle errors, rather than
     // calling stat() to see if it'll work.


### PR DESCRIPTION
This reverts commit 0be5954ac3fd5df6f0a749f37de8dca316b689b7.

It seems that this issue has already been resolved: https://github.com/rust-lang/rust/pull/129085#issuecomment-2288553490.