### PR TITLE
Backport of Wasm 64-bit table fix

### DIFF
--- a/lld/wasm/SyntheticSections.cpp
+++ b/lld/wasm/SyntheticSections.cpp
@@ -587,8 +587,7 @@ void ElemSection::writeBody() {
     initExpr.Inst.Value.Global = WasmSym::tableBase->getGlobalIndex();
   } else {
     bool is64 = config->is64.value_or(false);
-    initExpr.Inst.Opcode = is64 ? WASM_OPCODE_I64_CONST : WASM_OPCODE_I32_CONST;
-    initExpr.Inst.Value.Int32 = config->tableBase;
+    initExpr = intConst(config->tableBase, is64);
   }
   writeInitExpr(os, initExpr);
 


### PR DESCRIPTION
The `wasm64-unknown-unkown` target produces invalid Wasm modules due to an issue with 64-bit tables that was fixed in https://github.com/llvm/llvm-project/pull/107780. This is a backport of that fix which gets the `wasm64` target working again.

Here are steps to reproduce the issue:

```
❯ rustc +nightly --version
rustc 1.85.0-nightly (a224f3807 2024-12-09)

❯ cargo new --bin foo

❯ cd foo

❯ cargo +nightly build -Z build-std=std,panic_abort --target wasm64-unknown-unknown

❯ wasm-objdump -j Elem -x target/wasm64-unknown-unknown/debug/foo.wasm | head

foo.wasm:       file format wasm 0x1
module name: <foo-87b5668ca08bcff0.wasm>

Section Details:

Elem[1]:
 - segment[0] flags=0 table=0 count=91 - init i64=94235877441537
  - elem[94235877441537] = ref.func:3 <_ZN3foo4main17h3e4566f0ffb33d02E>
  - elem[94235877441538] = ref.func:5 <_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17ha696e16b756653ccE>
Here we can see the init expression for the table is reading uninitialized memory.
```

cc @alexcrichton @lwshang