### PR TITLE
fixup! [rust] Add CI Checks to Rust fork

### DIFF
--- a/.github/workflows/rust-premerge.yaml
+++ b/.github/workflows/rust-premerge.yaml
@@ -26,8 +26,8 @@ jobs:
   premerge-checks-linux:
     name: Build and Test Linux
     if: >-
-        github.repository_owner == 'rust-lang' &&
-        (github.event_name != 'pull_request' || github.event.action != 'closed')
+      github.repository_owner == 'rust-lang' &&
+      (github.event_name != 'pull_request' || github.event.action != 'closed')
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout LLVM
@@ -41,28 +41,16 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y clang-18 cmake ninja-build
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.17
-        with:
-          max-size: "2000M"
       - name: Build and Test
         run: |
-          projects_to_build='llvm;lld'
-          project_check_targets='check-llvm check-lld'
-          runtimes_to_build=''
-          runtimes_check_targets=''
-          runtimes_check_targets_needs_reconfig=''
-
-          echo "Building projects: ${projects_to_build}"
-          echo "Running project checks targets: ${project_check_targets}"
-          echo "Building runtimes: ${runtimes_to_build}"
-          echo "Running runtimes checks targets: ${runtimes_check_targets}"
-          echo "Running runtimes checks requiring reconfiguring targets: ${runtimes_check_targets_needs_reconfig}"
-
-          export CC=/usr/bin/clang-18
-          export CXX=/usr/bin/clang++-18
-
-          ./.ci/monolithic-linux.sh "${projects_to_build}" "${project_check_targets}" "${runtimes_to_build}" "${runtimes_check_targets}" "${runtimes_check_targets_needs_reconfig}"
+          cmake -S llvm -B build -G Ninja \
+            -DLLVM_ENABLE_PROJECTS=lld \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DLLVM_ENABLE_LLD=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=/usr/bin/clang-18 \
+            -DCMAKE_CXX_COMPILER=/usr/bin/clang++-18
+          ninja -C build check-llvm check-lld
 
   premerge-check-macos:
     name: Build and Test macOS
@@ -75,31 +63,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.17
-        with:
-          max-size: "2000M"
       - name: Build and Test
         run: |
-          projects_to_build='llvm'
-          project_check_targets='check-llvm'
-
-          echo "Building projects: ${projects_to_build}"
-          echo "Running project checks targets: ${project_check_targets}"
-
-          # -DLLVM_DISABLE_ASSEMBLY_FILES=ON is for
-          # https://github.com/llvm/llvm-project/issues/81967
-          # Disable sharding in lit so that the LIT_XFAIL environment var works.
-          cmake -G Ninja \
-                -B build \
-                -S llvm \
-                -DLLVM_ENABLE_PROJECTS="${projects_to_build}" \
-                -DLLVM_DISABLE_ASSEMBLY_FILES=ON \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DLLDB_INCLUDE_TESTS=OFF \
-                -DLLVM_ENABLE_ASSERTIONS=ON \
-                -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-
-          # The libcxx tests fail, so we are skipping the runtime targets.
-          ninja -C build ${project_check_targets}
+          cmake -S llvm -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLDB_INCLUDE_TESTS=OFF \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DCMAKE_C_COMPILER=/usr/bin/clang \
+            -DCMAKE_CXX_COMPILER=/usr/bin/clang++
+          ninja -C build check-llvm


### PR DESCRIPTION
From https://github.com/rust-lang/llvm-project/pull/186#discussion_r2269376477.
This patch removes ccache, sccahe and `monolithic-linux.sh`. Using CMake and Ninja directly here should be more reliable.